### PR TITLE
Various fixes and cert/chain merge ability

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,5 @@
 /log
 .yardoc
 coverage
+.librarian
+.tmp

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,19 +1,21 @@
+---
 language: ruby
+sudo: false
 cache: bundler
-bundler_args: --without system_tests
-script: "bundle exec rake validate lint"
+bundler_args: --without development system_tests
+before_install: rm Gemfile.lock || true
+script: bundle exec rake test
+branches:
+  only:
+  - master
 matrix:
   fast_finish: true
   include:
   - rvm: 2.1.9
-    bundler_args: --without system_tests
     env: PUPPET_GEM_VERSION="~> 4.0" STRICT_VARIABLES="yes"
   - rvm: 2.1.5
-    bundler_args: --without system_tests
-    env: PUPPET_GEM_VERSION="~> 3.0" FUTURE_PARSER="yes"
+    env: PUPPET_GEM_VERSION="~> 3.0" FUTURE_PARSER="yes" CACHE_NAME="FUTURE1"
   - rvm: 2.1.5
-    bundler_args: --without system_tests
     env: PUPPET_GEM_VERSION="~> 3.0"
   - rvm: 2.2
-    bundler_args: --without system_tests
     env: PUPPET_GEM_VERSION="~> 4.0" STRICT_VARIABLES="yes"

--- a/Gemfile
+++ b/Gemfile
@@ -1,10 +1,14 @@
 source 'https://rubygems.org'
 
+puppetversion = ENV['PUPPET_GEM_VERSION']
+gem 'facter', '>= 1.7.0'
+gem 'librarian-puppet'
+gem 'metadata-json-lint'
+gem 'puppet', puppetversion
+gem 'puppetlabs_spec_helper', '>= 0.1.0'
+gem 'puppet-lint', '>= 0.3.2'
+gem 'puppet-syntax'
 gem 'rake'
-gem 'puppet', ENV['PUPPET_GEM_VERSION'] || '>= 3.8.0'
+gem 'requests'
 gem 'rspec'
 gem 'rspec-puppet'
-gem 'puppetlabs_spec_helper'
-gem 'puppet-lint'
-gem 'puppet-syntax'
-gem 'metadata-json-lint'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -5,15 +5,35 @@ GEM
     diff-lcs (1.2.5)
     facter (2.4.6)
       CFPropertyList (~> 2.2.6)
+    faraday (0.9.2)
+      multipart-post (>= 1.2, < 3)
+    faraday_middleware (0.10.0)
+      faraday (>= 0.7.4, < 0.10)
+    fast_gettext (1.1.0)
+    gettext (3.2.2)
+      locale (>= 2.0.5)
+      text (>= 1.3.0)
+    gettext-setup (0.6)
+      fast_gettext (~> 1.1.0)
+      gettext (>= 3.0.2)
     hiera (3.2.1)
     json (2.0.2)
     json_pure (1.8.3)
+    librarian-puppet (2.2.3)
+      librarianp (>= 0.6.3)
+      puppet_forge (~> 2.1)
+      rsync
+    librarianp (0.6.3)
+      thor (~> 0.15)
+    locale (2.1.2)
     metaclass (0.0.4)
     metadata-json-lint (0.0.11)
       json
       spdx-licenses (~> 1.0)
+    minitar (0.5.4)
     mocha (1.1.0)
       metaclass (~> 0.0.1)
+    multipart-post (2.0.0)
     puppet (4.6.1)
       CFPropertyList (~> 2.2.6)
       facter (> 2.0, < 4)
@@ -22,12 +42,19 @@ GEM
     puppet-lint (2.0.2)
     puppet-syntax (2.1.0)
       rake
+    puppet_forge (2.2.2)
+      faraday (~> 0.9.0)
+      faraday_middleware (>= 0.9.0, < 0.11.0)
+      gettext-setup (>= 0.3)
+      minitar
+      semantic_puppet (~> 0.1.0)
     puppetlabs_spec_helper (1.2.1)
       mocha (~> 1.0)
       puppet-lint (~> 2.0)
       puppet-syntax (~> 2.0)
       rspec-puppet (~> 2.0)
     rake (11.2.2)
+    requests (1.0.0)
     rspec (3.5.0)
       rspec-core (~> 3.5.0)
       rspec-expectations (~> 3.5.0)
@@ -43,17 +70,28 @@ GEM
     rspec-puppet (2.4.0)
       rspec
     rspec-support (3.5.0)
+    rsync (1.0.9)
+    semantic_puppet (0.1.4)
+      gettext-setup (>= 0.3)
     spdx-licenses (1.1.0)
+    text (1.3.1)
+    thor (0.19.1)
 
 PLATFORMS
   ruby
 
 DEPENDENCIES
+  facter (>= 1.7.0)
+  librarian-puppet
   metadata-json-lint
-  puppet (>= 3.8.0)
-  puppet-lint
+  puppet
+  puppet-lint (>= 0.3.2)
   puppet-syntax
-  puppetlabs_spec_helper
+  puppetlabs_spec_helper (>= 0.1.0)
   rake
+  requests
   rspec
   rspec-puppet
+
+BUNDLED WITH
+   1.12.5

--- a/README.md
+++ b/README.md
@@ -1,4 +1,6 @@
 # certs
+[![Build Status](https://travis-ci.org/broadinstitute/puppet-certs.svg?branch=master)](https://travis-ci.org/broadinstitute/puppet-certs)
+[![License (Apache 2.0)](https://img.shields.io/badge/license-Apache-blue.svg)](https://opensource.org/licenses/Apache-2.0)
 
 #### Table of Contents
 

--- a/Rakefile
+++ b/Rakefile
@@ -1,9 +1,10 @@
+require 'rubygems'
 require 'bundler/setup'
+
 require 'puppet-lint/tasks/puppet-lint'
 require 'puppet-syntax/tasks/puppet-syntax'
 require 'puppet/version'
 require 'puppetlabs_spec_helper/rake_tasks'
-require 'rubygems'
 
 exclude_paths = [
   "bundle/**/*",
@@ -15,19 +16,39 @@ exclude_paths = [
 Rake::Task[:lint].clear
 
 PuppetLint.configuration.relative = true
-PuppetLint.configuration.disable_80chars
-PuppetLint.configuration.disable_documentation
-PuppetLint.configuration.disable_class_inherits_from_params_class
+PuppetLint.configuration.send("disable_80chars")
+PuppetLint.configuration.log_format = "%{path}:%{linenumber}:%{check}:%{KIND}:%{message}"
 PuppetLint.configuration.fail_on_warnings = true
+PuppetLint.configuration.disable_documentation
 
-PuppetLint::RakeTask.new :lint do |config|
-  config.ignore_paths = exclude_paths
-end
+# Forsake support for Puppet 2.6.2 for the benefit of cleaner code.
+# http://puppet-lint.com/checks/class_parameter_defaults/
+PuppetLint.configuration.send('disable_class_parameter_defaults')
+# http://puppet-lint.com/checks/class_inherits_from_params_class/
+PuppetLint.configuration.send('disable_class_inherits_from_params_class')
+# To fix unquoted cases in spec/fixtures/modules/apt/manifests/key.pp
+PuppetLint.configuration.send('disable_unquoted_string_in_case')
+
+PuppetLint.configuration.ignore_paths = exclude_paths
 
 PuppetSyntax.exclude_paths = exclude_paths
 
-desc "Run syntax and lint tests."
-task :default => [
+# These two gems aren't always present, for instance
+# on Travis with --without development
+
+begin
+  require 'puppet_blacksmith/rake_tasks'
+rescue LoadError
+end
+
+task :metadata_lint do
+  sh "bundle exec metadata-json-lint metadata.json"
+end
+
+desc "Run syntax, lint, and spec tests."
+task :test => [
   :syntax,
   :lint,
+  :spec,
+  :metadata_lint,
 ]

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,0 +1,31 @@
+# -*- mode: ruby -*-
+# vi: set ft=ruby :
+
+Vagrant.configure(2) do |config|
+  # config.vm.box = "centos/7"
+  config.vm.box = "puppetlabs/centos-7.2-64-nocm"
+  # config.vm.box_check_update = false
+  # config.vm.network "forwarded_port", guest: 80, host: 8080
+  # config.vm.network "private_network", ip: "192.168.33.10"
+  # config.vm.network "public_network"
+
+  config.vm.network "private_network", type: "dhcp",
+    virtualbox__intnet: "vboxnet1"
+
+  config.vm.hostname = "puppet-certs.example.com"
+
+  config.vm.provider "virtualbox" do |vb|
+   vb.gui = false
+   vb.memory = "1024"
+   vb.name = "puppet-certs"
+  end
+
+  config.vm.provision "file", source: "Gemfile", destination: "/tmp/Gemfile"
+  config.vm.provision "file", source: "Gemfile.lock", destination: "/tmp/Gemfile.lock"
+  config.vm.provision "file", source: "vagrant_files/hiera.yaml", destination: "/tmp/hiera.yaml"
+  config.vm.provision "shell", path: "vagrant_files/centos7-init.sh"
+
+  config.vm.synced_folder ".", "/etc/puppetlabs/code/modules/certs"
+
+  config.ssh.insert_key = false
+end

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -13,7 +13,10 @@
 # Copyright 2016
 #
 class certs (
-  $sites = hiera_hash('certs::sites', undef),
-) inherits ::certs::params {
-  create_resources('certs::site', $sites)
+  $sites = hiera_hash('certs::sites', {}),
+) {
+
+    include ::certs::params
+
+    create_resources('certs::site', $sites)
 }

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -101,6 +101,19 @@
 # Permissions of the private keys.
 # Optional value. Default: '0600'.
 #
+# [cert_dir_mode]
+# Permissions of the certificate directory.
+# Optional value. Default: '0755'.
+#
+# [key_dir_mode]
+# Permissions of the private keys directory.
+# Optional value. Default: '0755'.
+#
+# [merge_chain]
+# Option to merge the intermediate chain into the actual certificate file,
+# which is required by some software.
+# Optional value. Default: false.
+#
 class certs::params {
   case $::osfamily {
     'RedHat': {
@@ -131,17 +144,20 @@ class certs::params {
       fail("Class['certs::params']: Unsupported osfamily: ${::osfamily}")
     }
   }
-  $cert_ext   = '.crt'
-  $key_ext    = '.key'
-  $cert_chain = false
-  $chain_name = ''
-  $chain_ext  = $cert_ext
-  $chain_path = $cert_path
-  $ca_cert    = false
-  $ca_name    = ''
-  $ca_ext     = $cert_ext
-  $ca_path    = $cert_path
-  $owner      = 'root'
-  $cert_mode  = 0644
-  $key_mode   = 0600
+  $cert_ext      = '.crt'
+  $key_ext       = '.key'
+  $cert_chain    = false
+  $chain_name    = ''
+  $chain_ext     = $cert_ext
+  $chain_path    = $cert_path
+  $ca_cert       = false
+  $ca_name       = ''
+  $ca_ext        = $cert_ext
+  $ca_path       = $cert_path
+  $owner         = 'root'
+  $cert_mode     = '0644'
+  $key_mode      = '0600'
+  $cert_dir_mode = '0755'
+  $key_dir_mode  = '0755'
+  $merge_chain   = false
 }

--- a/manifests/site.pp
+++ b/manifests/site.pp
@@ -69,6 +69,9 @@ define certs::site(
   $group             = $::certs::params::group,
   $cert_mode         = $::certs::params::cert_mode,
   $key_mode          = $::certs::params::key_mode,
+  $cert_dir_mode     = $::certs::params::cert_dir_mode,
+  $key_dir_mode      = $::certs::params::key_dir_mode,
+  $merge_chain       = $::certs::params::merge_chain,
 ) {
   if ($name == undef) {
     fail('You must provide a name value for the site to certs::site.')
@@ -99,8 +102,15 @@ define certs::site(
     }
   }
   validate_string($owner, $group)
+  validate_string($cert_mode)
   validate_numeric($cert_mode)
+  validate_string($key_mode)
   validate_numeric($key_mode)
+  validate_string($cert_dir_mode)
+  validate_numeric($cert_dir_mode)
+  validate_string($key_dir_mode)
+  validate_numeric($key_dir_mode)
+  validate_bool($merge_chain)
 
   $cert = "${name}${cert_ext}"
   $key = "${name}${key_ext}"
@@ -120,42 +130,122 @@ define certs::site(
     }
   }
 
-  file { "${cert_path}/${cert}":
-    ensure => file,
-    source => "${source_path}/${cert}",
-    owner  => $owner,
-    group  => $group,
-    mode   => $cert_mode,
-    notify => $service_notify,
-  } ->
+  if !defined(File[$cert_path]) {
+    file { $cert_path:
+      ensure => 'directory',
+      backup => false,
+      owner  => $owner,
+      group  => $group,
+      mode   => $cert_dir_mode,
+    }
+  }
+
+  if !defined(File[$chain_path]) {
+    file { $chain_path:
+      ensure => 'directory',
+      backup => false,
+      owner  => $owner,
+      group  => $group,
+      mode   => $cert_dir_mode,
+    }
+  }
+
+  if !defined(File[$ca_path]) {
+    file { $ca_path:
+      ensure => 'directory',
+      backup => false,
+      owner  => $owner,
+      group  => $group,
+      mode   => $cert_dir_mode,
+    }
+  }
+
+  if !defined(File[$keys_path]) {
+    file { $keys_path:
+      ensure => 'directory',
+      backup => false,
+      owner  => $owner,
+      group  => $group,
+      mode   => $key_dir_mode,
+    }
+  }
+
+  if $merge_chain {
+    concat { "${name}_cert_merged":
+      ensure         => 'present',
+      ensure_newline => true,
+      backup         => false,
+      path           => "${cert_path}/${cert}",
+      owner          => $owner,
+      group          => $group,
+      mode           => $cert_mode,
+      require        => File[$cert_path],
+      notify         => $service_notify,
+    }
+
+    concat::fragment { "${cert}_certificate":
+      target => "${name}_cert_merged",
+      source => "${source_path}/${cert}",
+      order  => '01'
+    }
+
+    if $cert_chain {
+      concat::fragment { "${cert}_chain":
+        target => "${name}_cert_merged",
+        source => "${chain_source_path}/${chain}",
+        order  => '50'
+      }
+    }
+    if $ca_cert {
+      concat::fragment { "${cert}_ca":
+        target => "${name}_cert_merged",
+        source => "${ca_source_path}/${ca}",
+        order  => '90'
+      }
+    }
+  } else {
+    file { "${cert_path}/${cert}":
+      ensure  => file,
+      source  => "${source_path}/${cert}",
+      owner   => $owner,
+      group   => $group,
+      mode    => $cert_mode,
+      require => File[$cert_path],
+      notify  => $service_notify,
+    }
+  }
+
   file { "${keys_path}/${key}":
-    ensure => file,
-    source => "${source_path}/${key}",
-    owner  => $owner,
-    group  => $group,
-    mode   => $key_mode,
-    notify => $service_notify,
+    ensure  => file,
+    source  => "${source_path}/${key}",
+    owner   => $owner,
+    group   => $group,
+    mode    => $key_mode,
+    require => File[$keys_path],
+    notify  => $service_notify,
   }
 
   if ($cert_chain and !defined(File["${chain_path}/${chain}"])) {
     file { "${chain_path}/${chain}":
-      ensure => file,
-      source => "${chain_source_path}/${chain}",
-      owner  => $owner,
-      group  => $group,
-      mode   => $cert_mode,
-      notify => $service_notify,
+      ensure  => file,
+      source  => "${chain_source_path}/${chain}",
+      owner   => $owner,
+      group   => $group,
+      mode    => $cert_mode,
+      require => File[$chain_path],
+      notify  => $service_notify,
     }
   }
 
   if ($ca_cert and !defined(File["${ca_path}/${ca}"])) {
     file { "${ca_path}/${ca}":
-      ensure => file,
-      source => "${ca_source_path}/${ca}",
-      owner  => $owner,
-      group  => $group,
-      mode   => $cert_mode,
-      notify => $service_notify,
+      ensure  => file,
+      source  => "${ca_source_path}/${ca}",
+      owner   => $owner,
+      group   => $group,
+      mode    => $cert_mode,
+      require => File[$ca_path],
+      notify  => $service_notify,
     }
   }
 }

--- a/metadata.json
+++ b/metadata.json
@@ -65,9 +65,8 @@
     }
   ],
   "dependencies": [
-    {
-      "name":"puppetlabs-stdlib","version_requirement":">= 4.0.0 < 5.0.0"
-    }
+    { "name":"puppetlabs-stdlib","version_requirement":">= 4.0.0 < 5.0.0" },
+    { "name":"puppetlabs/concat","version_requirement":">= 1.1.1 < 3.0.0" }
   ],
   "requirements": [
     {

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -1,0 +1,40 @@
+require 'spec_helper'
+
+describe 'certs', :type => :class do
+
+  [ 'Debian', 'RedHat' ].each do |osfamily|
+
+    context "on #{osfamily}" do
+
+      if osfamily == 'Debian'
+        let(:facts) { {
+          :osfamily               => 'Debian',
+          :operatingsystem        => 'Debian',
+          :lsbdistid              => 'Debian',
+          :lsbdistcodename        => 'wheezy',
+          :kernelrelease          => '3.2.0-4-amd64',
+          :operatingsystemrelease => '7.3',
+          :operatingsystemmajrelease => '7',
+        } }
+
+        context 'with defaults for all parameters' do
+          it { should contain_class('certs') }
+        end
+      end
+
+      if osfamily == 'RedHat'
+        let(:facts) { {
+          :osfamily => osfamily,
+          :operatingsystem => 'RedHat',
+          :operatingsystemrelease => '7.2',
+          :operatingsystemmajrelease => '7',
+        } }
+
+        context 'with defaults for all parameters' do
+          it { should contain_class('certs') }
+        end
+      end
+
+    end
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,0 +1,2 @@
+require 'rubygems'
+require 'puppetlabs_spec_helper/module_spec_helper'

--- a/tests/init.pp
+++ b/tests/init.pp
@@ -1,0 +1,12 @@
+# The baseline for module testing used by Puppet Labs is that each manifest
+# should have a corresponding test manifest that declares that class or defined
+# type.
+#
+# Tests are then run by using puppet apply --noop (to check for compilation
+# errors and view a log of events) or by fully applying the test in a virtual
+# environment (to compare the resulting system state to the desired state).
+#
+# Learn more about module testing here:
+# http://docs.puppetlabs.com/guides/tests_smoke.html
+#
+include certs

--- a/vagrant_files/centos7-init.sh
+++ b/vagrant_files/centos7-init.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+
+rpm -Uvh https://yum.puppetlabs.com/puppetlabs-release-el-7.noarch.rpm
+rpm --import /etc/pki/rpm-gpg/RPM-GPG-KEY-puppetlabs
+yum -y install git puppet ruby-devel vim
+mv /tmp/Gemfile /etc/puppetlabs/code/
+mv /tmp/Gemfile.lock /etc/puppetlabs/code/
+mv /tmp/hiera.yaml /etc/puppetlabs/code/
+mkdir -p /etc/puppetlabs/code/hieradata
+mkdir -p /etc/puppetlabs/code/modules
+touch /etc/puppetlabs/code/hieradata/global.yaml
+gem install bundle rake --no-rdoc --no-ri
+/usr/local/bin/bundle config --global silence_root_warning 1
+cd /etc/puppetlabs/code
+/usr/local/bin/bundle install
+cd /etc/puppetlabs/code/modules/certs
+rm -f Puppetfile.lock
+/usr/local/bin/librarian-puppet install --verbose --path=/etc/puppetlabs/code/modules

--- a/vagrant_files/hiera.yaml
+++ b/vagrant_files/hiera.yaml
@@ -1,0 +1,7 @@
+---
+:backends:
+    - yaml
+:hierarchy:
+    - global
+:yaml:
+    :datadir: /etc/puppetlabs/code/hieradata


### PR DESCRIPTION
* Add cert/chain merge ability
* Add Vagrant support for testing using Puppet 4
* Fix small default bug in init.pp and get rake tests working
* .travis.yml cleanup
* Fix Future Parser error
* Make sure Travis runs in container mode
* Add badges
* Stop using inherits for params in certs class
* Make sure directories exist before placing cert/key files there
* Fix validation to make sure file/directory modes are strings and numeric, not just numeric
* Change file/directory mode defaults to strings
* Fix chain merging
* Stop building on all branches in Travis, only master and PRs