### PR TITLE
Testing fixes and global default settings

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -1,0 +1,6 @@
+fixtures:
+  repositories:
+    concat: git://github.com/puppetlabs/puppetlabs-concat.git
+    stdlib: git://github.com/puppetlabs/puppetlabs-stdlib.git
+  symlinks:
+    certs: "#{source_dir}"

--- a/README.md
+++ b/README.md
@@ -114,6 +114,32 @@ Examples
   Certs::Site<| |> -> Apache::Vhost<| |>
 ~~~
 
+You can also reset some of the settings in params.pp globally via the **certs** base class which will be inherited by all **certs::site** defines used that are later defined.  In this example, we can reset the default certificate and key paths for all instantiated sites so that we don't have to manually set the custom path in each site:
+
+~~~
+  $domain1 = 'www.example.com'
+  $domain2 = 'foo.example.com'
+
+  class { 'certs':
+    cert_path => '/path/to/certs',
+    key_path  => '/path/to/keys',
+  }
+
+  certs::site { $domain1:
+    source_path    => 'puppet:///site_certificates',
+    ca_cert        => true,
+    ca_name        => 'caname',
+    ca_source_path => 'puppet:///ca_certs',
+  }
+
+  certs::site { $domain2:
+    source_path    => 'puppet:///site_certificates',
+    ca_cert        => true,
+    ca_name        => 'caname',
+    ca_source_path => 'puppet:///ca_certs',
+  }
+~~~
+
 ## Reference
 
 - [**Public classes**](#public-classes)

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -13,10 +13,65 @@
 # Copyright 2016
 #
 class certs (
-  $sites = hiera_hash('certs::sites', {}),
+  $cert_ext      = undef,
+  $cert_path     = undef,
+  $key_ext       = undef,
+  $key_path      = undef,
+  $chain_ext     = undef,
+  $chain_path    = undef,
+  $ca_ext        = undef,
+  $ca_path       = undef,
+  $service       = undef,
+  $owner         = undef,
+  $group         = undef,
+  $cert_mode     = undef,
+  $key_mode      = undef,
+  $cert_dir_mode = undef,
+  $key_dir_mode  = undef,
+  $sites         = hiera_hash('certs::sites', {}),
 ) {
 
-    include ::certs::params
+  include ::certs::params
 
-    create_resources('certs::site', $sites)
+  $_cert_ext      = pick_default($cert_ext, $::certs::params::cert_ext)
+  $_cert_path     = pick_default($cert_path, $::certs::params::cert_path)
+  $_key_ext       = pick_default($key_ext, $::certs::params::key_ext)
+  $_key_path      = pick_default($key_path, $::certs::params::key_path)
+  $_chain_ext     = pick_default($chain_ext, $::certs::params::chain_ext)
+  $_chain_path    = pick_default($chain_path, $::certs::params::chain_path)
+  $_ca_ext        = pick_default($ca_ext, $::certs::params::ca_ext)
+  $_ca_path       = pick_default($ca_path, $::certs::params::ca_path)
+  $_service       = pick_default($service, $::certs::params::service)
+  $_owner         = pick_default($owner, $::certs::params::owner)
+  $_group         = pick_default($group, $::certs::params::group)
+  $_cert_mode     = pick_default($cert_mode, $::certs::params::cert_mode)
+  $_key_mode      = pick_default($key_mode, $::certs::params::key_mode)
+  $_cert_dir_mode = pick_default($cert_dir_mode, $::certs::params::cert_dir_mode)
+  $_key_dir_mode  = pick_default($key_dir_mode, $::certs::params::key_dir_mode)
+
+  validate_string($_cert_ext)
+  validate_absolute_path($_cert_path)
+  validate_string($_key_ext)
+  validate_absolute_path($_key_path)
+  validate_string($_chain_ext)
+  validate_absolute_path($_chain_path)
+  validate_string($_ca_ext)
+  validate_absolute_path($_ca_path)
+
+  if $service != '' {
+    validate_string($service)
+  }
+
+  validate_string($_owner)
+  validate_string($_group)
+  validate_string($_cert_mode)
+  validate_numeric($_cert_mode)
+  validate_string($_key_mode)
+  validate_numeric($_key_mode)
+  validate_string($_cert_dir_mode)
+  validate_numeric($_cert_dir_mode)
+  validate_string($_key_dir_mode)
+  validate_numeric($_key_dir_mode)
+
+  create_resources('certs::site', $sites)
 }

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -23,7 +23,7 @@
 #   - '/usr/local/etc/apache24' on FreeBSD-based systems
 #   - '/etc/ssl/apache2' on Gentoo-based systems
 #
-# [keys_path]
+# [key_path]
 # Location where the private keys will be stored on the managed node.
 # Optional value. Defaults:
 #   - '/etc/pki/tls/private' on RedHat-based systems
@@ -117,28 +117,28 @@
 class certs::params {
   case $::osfamily {
     'RedHat': {
-      $cert_path  = '/etc/pki/tls/certs'
-      $keys_path  = '/etc/pki/tls/private'
-      $service    = 'httpd'
-      $group      = 'root'
+      $cert_path = '/etc/pki/tls/certs'
+      $key_path  = '/etc/pki/tls/private'
+      $service   = 'httpd'
+      $group     = 'root'
     }
     'Debian', 'Suse': {
-      $cert_path  = '/etc/ssl/certs'
-      $keys_path  = '/etc/ssl/private'
-      $service    = 'apache2'
-      $group      = 'root'
+      $cert_path = '/etc/ssl/certs'
+      $key_path  = '/etc/ssl/private'
+      $service   = 'apache2'
+      $group     = 'root'
     }
     'FreeBSD': {
-      $cert_path  = '/usr/local/etc/apache24'
-      $keys_path  = '/usr/local/etc/apache24'
-      $service    = 'apache24'
-      $group      = 'wheel'
+      $cert_path = '/usr/local/etc/apache24'
+      $key_path  = '/usr/local/etc/apache24'
+      $service   = 'apache24'
+      $group     = 'wheel'
     }
     'Gentoo': {
-      $cert_path  = '/etc/ssl/apache2'
-      $keys_path  = '/etc/ssl/apache2'
-      $service    = 'apache2'
-      $group      = 'wheel'
+      $cert_path = '/etc/ssl/apache2'
+      $key_path  = '/etc/ssl/apache2'
+      $service   = 'apache2'
+      $group     = 'wheel'
     }
     default: {
       fail("Class['certs::params']: Unsupported osfamily: ${::osfamily}")
@@ -146,11 +146,9 @@ class certs::params {
   }
   $cert_ext      = '.crt'
   $key_ext       = '.key'
-  $cert_chain    = false
   $chain_name    = ''
   $chain_ext     = $cert_ext
   $chain_path    = $cert_path
-  $ca_cert       = false
   $ca_name       = ''
   $ca_ext        = $cert_ext
   $ca_path       = $cert_path
@@ -159,5 +157,4 @@ class certs::params {
   $key_mode      = '0600'
   $cert_dir_mode = '0755'
   $key_dir_mode  = '0755'
-  $merge_chain   = false
 }


### PR DESCRIPTION
* Add a .fixtures.yml to make sure all dependencies are installed before tests run
* Add the ability to set defaults for all sites via init.pp
* Add to README
* Add a check in site.pp to make sure the base (certs) class is defined