### PR TITLE
Add tests, content instead of source logic, and ensure support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,5 @@
 coverage
 .librarian
 .tmp
+.DS_Store
+tmp/*

--- a/.rspec
+++ b/.rspec
@@ -1,0 +1,1 @@
+--format documentation

--- a/README.md
+++ b/README.md
@@ -193,7 +193,7 @@ e.g. *'puppet:///site_certs'* will search for the mount point defined in `filese
 ##### `cert_ext`
 The extension of the certificate file.
 
-Optional value. **Default: crt.**
+Optional value. **Default: '.crt'.**
 
 ##### `cert_path`
 Location where the certificate files will be stored on the managed node.
@@ -203,6 +203,11 @@ Optional value. Defaults:
   - **Debian** and **SuSE**: `/etc/ssl/certs`
   - **FreeBSD**: `/usr/local/etc/apache24`
   - **Gentoo**: `/etc/ssl/apache2`
+
+##### `key_ext`
+The extension of the private key file.
+
+Optional value. **Default: '.key'.**
 
 ##### `key_path`
 Location where the private keys will be stored on the managed node.
@@ -317,7 +322,7 @@ Optional value. **Default: false.**
 ## Limitations
 
 This module is CI tested against [open source Puppet](https://docs.puppetlabs.com/puppet) on:
-- Centos 5 and 6
+- CentOS 5 and 6
 - RHEL 5, 6, and 7
 
 This module also provides functions for other distributions and operating systems, such as FreeBSD and Gentoo, but is not formally tested on them and are subject to regressions.
@@ -326,7 +331,7 @@ No issues have been identified as of yet.
 
 ## Release Notes
 
-### 1.0.0 (September 2, 2016)
+### 1.0.0 (September 6, 2016)
 #### Summary
 * Introducing new features, primarily an option to merge certificates for services that require it
 * Adding Vagrant support for testing using Puppet 4

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -58,7 +58,7 @@ class certs (
   validate_string($_ca_ext)
   validate_absolute_path($_ca_path)
 
-  if $service != '' {
+  if $service != undef {
     validate_string($service)
   }
 

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -13,7 +13,7 @@
 #
 # [cert_ext]
 # The extension of the certificate file.
-# Optional value. Default: crt.
+# Optional value. Default: '.crt'.
 #
 # [cert_path]
 # Location where the certificate files will be stored on the managed node.
@@ -22,6 +22,10 @@
 #   - '/etc/ssl/certs' on Debian-based and Suse-based systems
 #   - '/usr/local/etc/apache24' on FreeBSD-based systems
 #   - '/etc/ssl/apache2' on Gentoo-based systems
+#
+# [key_ext]
+# The extension of the private key file.
+# Optional value. Default: '.key'.
 #
 # [key_path]
 # Location where the private keys will be stored on the managed node.
@@ -146,10 +150,10 @@ class certs::params {
   }
   $cert_ext      = '.crt'
   $key_ext       = '.key'
-  $chain_name    = ''
+  $chain_name    = undef
   $chain_ext     = $cert_ext
   $chain_path    = $cert_path
-  $ca_name       = ''
+  $ca_name       = undef
   $ca_ext        = $cert_ext
   $ca_path       = $cert_path
   $owner         = 'root'

--- a/metadata.json
+++ b/metadata.json
@@ -1,7 +1,10 @@
 {
   "name": "broadinstitute-certs",
   "version": "1.0.0",
-  "author": "Riccardo Calixte <rcalixte@broadinstitute.org>",
+  "author": [
+    "Riccardo Calixte <rcalixte@broadinstitute.org>",
+    "Andrew Teixeira <teixeira@broadinstitute.org"
+  ],
   "description": "Module for SSL certificate configuration",
   "summary": "Configures and manages SSL certificate deployments, restarting services as configured.",
   "license": "Apache-2.0",

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -2,7 +2,7 @@ require 'spec_helper'
 
 describe 'certs', :type => :class do
 
-  [ 'Debian', 'RedHat' ].each do |osfamily|
+  [ 'Debian', 'FreeBSD', 'Gentoo', 'RedHat' ].each do |osfamily|
 
     context "on #{osfamily}" do
 
@@ -12,7 +12,6 @@ describe 'certs', :type => :class do
           :operatingsystem        => 'Debian',
           :lsbdistid              => 'Debian',
           :lsbdistcodename        => 'wheezy',
-          :kernelrelease          => '3.2.0-4-amd64',
           :operatingsystemrelease => '7.3',
           :operatingsystemmajrelease => '7',
         } }
@@ -20,6 +19,33 @@ describe 'certs', :type => :class do
         context 'with defaults for all parameters' do
           it { should contain_class('certs') }
         end
+      end
+
+      if osfamily == 'FreeBSD'
+        let(:facts) { {
+          :osfamily => osfamily,
+          :operatingsystem => 'FreeBSD',
+          :operatingsystemrelease => '10.0-RELEASE-p18',
+          :operatingsystemmajrelease => '10',
+        } }
+
+        context 'with defaults for all parameters' do
+          it { should contain_class('certs') }
+        end
+
+      end
+
+      if osfamily == 'Gentoo'
+        let(:facts) { {
+          :osfamily => osfamily,
+          :operatingsystem => 'Gentoo',
+          :operatingsystemrelease => '3.16.1-gentoo',
+        } }
+
+        context 'with defaults for all parameters' do
+          it { should contain_class('certs') }
+        end
+
       end
 
       if osfamily == 'RedHat'

--- a/spec/defines/site_spec.rb
+++ b/spec/defines/site_spec.rb
@@ -1,0 +1,391 @@
+require 'spec_helper'
+
+describe 'certs::site', :type => :define do
+  let (:title) { 'base.example.org' }
+
+  [ 'Debian', 'FreeBSD', 'Gentoo', 'RedHat', 'Suse' ].each do |osfamily|
+
+    context "on #{osfamily}" do
+      # This define requires the certs class, so make sure it's defined
+      let :pre_condition do
+        'class { "certs": }'
+      end
+
+      if osfamily == 'Debian'
+        let(:facts) { {
+          :osfamily                  => 'Debian',
+          :operatingsystem           => 'Debian',
+          :lsbdistid                 => 'Debian',
+          :lsbdistcodename           => 'wheezy',
+          :operatingsystemrelease    => '7.3',
+          :operatingsystemmajrelease => '7',
+        } }
+
+        context 'with only cert and key content set' do
+          let(:params) {
+            {
+              :cert_content => 'cert1111',
+              :key_content  => 'key1111',
+              :service      => :undef,
+            }
+          }
+
+          it { should contain_file('/etc/ssl/certs').with_ensure('directory') }
+          it { should contain_file('/etc/ssl/private').with_ensure('directory') }
+          it { should contain_file('/etc/ssl/certs/base.example.org.crt').with_group('root') }
+          it { should contain_file('/etc/ssl/private/base.example.org.key').with_group('root') }
+        end
+
+      end
+
+      if osfamily == 'FreeBSD'
+        let(:facts) { {
+          :osfamily                  => osfamily,
+          :operatingsystem           => 'FreeBSD',
+          :operatingsystemrelease    => '10.0-RELEASE-p18',
+          :operatingsystemmajrelease => '10',
+        } }
+
+        context 'with only cert and key content set' do
+          let(:params) {
+            {
+              :cert_content => 'cert1111',
+              :key_content  => 'key1111',
+              :service      => :undef,
+            }
+          }
+
+          it { should contain_file('/usr/local/etc/apache24').with_ensure('directory') }
+          it { should contain_file('/usr/local/etc/apache24').with_group('wheel') }
+          it { should contain_file('/usr/local/etc/apache24/base.example.org.crt').with_group('wheel') }
+          it { should contain_file('/usr/local/etc/apache24/base.example.org.key').with_group('wheel') }
+        end
+
+      end
+
+      if osfamily == 'Gentoo'
+        let(:facts) { {
+          :osfamily               => osfamily,
+          :operatingsystem        => 'Gentoo',
+          :operatingsystemrelease => '3.16.1-gentoo',
+        } }
+
+        context 'with only cert and key content set' do
+          let(:params) {
+            {
+              :cert_content => 'cert1111',
+              :key_content  => 'key1111',
+              :service      => :undef,
+            }
+          }
+
+          it { should contain_file('/etc/ssl/apache2').with_ensure('directory') }
+          it { should contain_file('/etc/ssl/apache2').with_group('wheel') }
+          it { should contain_file('/etc/ssl/apache2/base.example.org.crt').with_group('wheel') }
+          it { should contain_file('/etc/ssl/apache2/base.example.org.key').with_group('wheel') }
+        end
+
+      end
+
+      if osfamily == 'RedHat'
+        let(:facts) { {
+          :osfamily                  => osfamily,
+          :operatingsystem           => 'RedHat',
+          :operatingsystemrelease    => '7.2',
+          :operatingsystemmajrelease => '7',
+        } }
+
+        context 'with only cert and key content set' do
+          let(:params) {
+            {
+              :cert_content => 'cert1111',
+              :key_content  => 'key1111',
+              :service      => :undef,
+            }
+          }
+
+          it { should contain_file('/etc/pki/tls/certs').with_ensure('directory') }
+          it { should contain_file('/etc/pki/tls/private').with_ensure('directory') }
+          it { should contain_file('/etc/pki/tls/certs/base.example.org.crt').with_group('root') }
+          it { should contain_file('/etc/pki/tls/private/base.example.org.key').with_group('root') }
+        end
+
+      end
+    end
+  end
+
+  context "on Debian-like setup for the remaining tests" do
+
+    let(:facts) { {
+      :osfamily                  => 'Debian',
+      :operatingsystem           => 'Debian',
+      :lsbdistid                 => 'Debian',
+      :lsbdistcodename           => 'wheezy',
+      :operatingsystemrelease    => '7.3',
+      :operatingsystemmajrelease => '7',
+    } }
+
+    # This define requires the certs class, so make sure it's defined
+    let :pre_condition do
+      'class { "certs":
+        cert_path => "/etc/ssl/certs",
+        key_path  => "/etc/ssl/private",
+      }'
+    end
+
+    context 'with only cert and key content set' do
+      let(:params) {
+        {
+          :cert_content => 'cert1111',
+          :key_content  => 'key1111',
+          :service      => :undef,
+        }
+      }
+
+      it { should contain_file('/etc/ssl/certs/base.example.org.crt').with_content(/cert1111/) }
+      it { should contain_file('/etc/ssl/private/base.example.org.key').with_content(/key1111/) }
+    end
+
+    context 'with ensure => absent' do
+      let(:params) {
+        {
+          :cert_content => 'cert',
+          :key_content  => 'key',
+          :service      => :undef,
+          :ensure       => 'absent'
+        }
+      }
+
+      it { should contain_file('/etc/ssl/certs/base.example.org.crt').with_ensure('absent') }
+      it { should contain_file('/etc/ssl/private/base.example.org.key').with_ensure('absent') }
+    end
+
+    context 'with CA cert' do
+      let(:params) {
+        {
+          :cert_content => 'cert1111',
+          :key_content  => 'key1111',
+          :service      => :undef,
+          :ca_cert      => true,
+          :ca_name      => 'ca',
+          :ca_content   => 'ca2222',
+          :ensure       => 'present'
+        }
+      }
+
+      it { should contain_file('/etc/ssl/certs/base.example.org.crt').with_content(/cert1111/) }
+      it { should contain_file('/etc/ssl/private/base.example.org.key').with_content(/key1111/) }
+      it { should contain_file('/etc/ssl/certs/ca.crt').with_content(/ca2222/) }
+    end
+
+    context 'with chain cert' do
+      let(:params) {
+        {
+          :cert_content => 'cert1111',
+          :key_content  => 'key1111',
+          :service      => :undef,
+          :ca_cert      => true,
+          :ca_name      => 'chain',
+          :ca_content   => 'chain3333',
+          :ensure       => 'present'
+        }
+      }
+
+      it { should contain_file('/etc/ssl/certs/base.example.org.crt').with_content(/cert1111/) }
+      it { should contain_file('/etc/ssl/private/base.example.org.key').with_content(/key1111/) }
+      it { should contain_file('/etc/ssl/certs/chain.crt').with_content(/chain3333/) }
+    end
+
+    context 'with merge_chain set to true with CA' do
+      let(:params) {
+        {
+          :cert_content => 'cert1111',
+          :key_content  => 'key1111',
+          :service      => :undef,
+          :ensure       => 'present',
+          :ca_cert      => true,
+          :ca_name      => 'ca',
+          :ca_content   => 'ca2222',
+          :merge_chain  => true
+        }
+      }
+
+      it { should contain_concat('base.example.org_cert_merged') }
+      it {
+        should contain_concat__fragment('base.example.org.crt_certificate').with(
+          :content => /cert1111/ )
+      }
+      it {
+        should contain_concat__fragment('base.example.org.crt_ca').with(
+          :content => /ca2222/ )
+      }
+      it { should contain_file('/etc/ssl/private/base.example.org.key').with_content(/key1111/) }
+      it { should contain_file('/etc/ssl/certs/ca.crt').with_content(/ca2222/) }
+    end
+
+    context 'with merge_chain set to true with chain' do
+      let(:params) {
+        {
+          :cert_content  => 'cert1111',
+          :key_content   => 'key1111',
+          :service       => :undef,
+          :ensure        => 'present',
+          :cert_chain    => true,
+          :chain_name    => 'chain',
+          :chain_content => 'chain3333',
+          :merge_chain   => true
+        }
+      }
+
+      it { should contain_concat('base.example.org_cert_merged') }
+      it {
+        should contain_concat__fragment('base.example.org.crt_certificate').with(
+          :content => /cert1111/ )
+      }
+      it {
+        should contain_concat__fragment('base.example.org.crt_chain').with(
+          :content => /chain3333/ )
+      }
+      it { should contain_file('/etc/ssl/private/base.example.org.key').with_content(/key1111/) }
+      it { should contain_file('/etc/ssl/certs/chain.crt').with_content(/chain3333/) }
+    end
+
+    context 'with merge_chain set to true with CA and chain' do
+      let(:params) {
+        {
+          :cert_content  => 'cert1111',
+          :key_content   => 'key1111',
+          :service       => :undef,
+          :ensure        => 'present',
+          :cert_chain    => true,
+          :chain_name    => 'chain',
+          :chain_content => 'chain3333',
+          :ca_cert       => true,
+          :ca_name       => 'ca',
+          :ca_content    => 'ca2222',
+          :merge_chain   => true
+        }
+      }
+
+      it { should contain_concat('base.example.org_cert_merged') }
+      it {
+        should contain_concat__fragment('base.example.org.crt_certificate').with(
+          :content => /cert1111/ )
+      }
+      it {
+        should contain_concat__fragment('base.example.org.crt_ca').with(
+          :content => /ca2222/ )
+      }
+      it {
+        should contain_concat__fragment('base.example.org.crt_chain').with(
+          :content => /chain3333/ )
+      }
+      it { should contain_file('/etc/ssl/private/base.example.org.key').with_content(/key1111/) }
+      it { should contain_file('/etc/ssl/certs/ca.crt').with_content(/ca2222/) }
+      it { should contain_file('/etc/ssl/certs/chain.crt').with_content(/chain3333/) }
+    end
+
+    context 'with a custom user set' do
+      let(:params) {
+        {
+          :cert_content  => 'cert1111',
+          :key_content   => 'key1111',
+          :service       => :undef,
+          :ensure        => 'present',
+          :cert_chain    => true,
+          :chain_name    => 'chain',
+          :chain_content => 'chain3333',
+          :ca_cert       => true,
+          :ca_name       => 'ca',
+          :ca_content    => 'ca2222',
+          :owner         => 'newowner',
+        }
+      }
+
+      it { should contain_file('/etc/ssl/certs/base.example.org.crt').with_owner('newowner') }
+      it { should contain_file('/etc/ssl/private/base.example.org.key').with_owner('newowner') }
+      it { should contain_file('/etc/ssl/certs/ca.crt').with_owner('newowner') }
+      it { should contain_file('/etc/ssl/certs/chain.crt').with_owner('newowner') }
+    end
+
+    context 'with a custom group set' do
+      let(:params) {
+        {
+          :cert_content  => 'cert1111',
+          :key_content   => 'key1111',
+          :service       => :undef,
+          :ensure        => 'present',
+          :cert_chain    => true,
+          :chain_name    => 'chain',
+          :chain_content => 'chain3333',
+          :ca_cert       => true,
+          :ca_name       => 'ca',
+          :ca_content    => 'ca2222',
+          :group         => 'newgroup',
+        }
+      }
+
+      it { should contain_file('/etc/ssl/certs/base.example.org.crt').with_group('newgroup') }
+      it { should contain_file('/etc/ssl/private/base.example.org.key').with_group('newgroup') }
+      it { should contain_file('/etc/ssl/certs/ca.crt').with_group('newgroup') }
+      it { should contain_file('/etc/ssl/certs/chain.crt').with_group('newgroup') }
+    end
+
+    context 'with a custom file and directory modes set' do
+      let(:params) {
+        {
+          :cert_content  => 'cert1111',
+          :key_content   => 'key1111',
+          :service       => :undef,
+          :ensure        => 'present',
+          :cert_chain    => true,
+          :chain_name    => 'chain',
+          :chain_content => 'chain3333',
+          :ca_cert       => true,
+          :ca_name       => 'ca',
+          :ca_content    => 'ca2222',
+          :cert_mode     => '0700',
+          :key_mode      => '0400',
+          :cert_dir_mode => '0500',
+          :key_dir_mode  => '0500',
+        }
+      }
+
+      it { should contain_file('/etc/ssl/certs').with_ensure('directory') }
+      it { should contain_file('/etc/ssl/certs').with_mode('0500') }
+      it { should contain_file('/etc/ssl/private').with_ensure('directory') }
+      it { should contain_file('/etc/ssl/private').with_mode('0500') }
+
+      it { should contain_file('/etc/ssl/certs/base.example.org.crt').with_mode('0700') }
+      it { should contain_file('/etc/ssl/private/base.example.org.key').with_mode('0400') }
+      it { should contain_file('/etc/ssl/certs/ca.crt').with_mode('0700') }
+      it { should contain_file('/etc/ssl/certs/chain.crt').with_mode('0700') }
+    end
+
+    context 'with custom extensions set' do
+      let(:params) {
+        {
+          :cert_content  => 'cert1111',
+          :key_content   => 'key1111',
+          :service       => :undef,
+          :ensure        => 'present',
+          :cert_chain    => true,
+          :chain_name    => 'chain',
+          :chain_content => 'chain3333',
+          :ca_cert       => true,
+          :ca_name       => 'ca',
+          :ca_content    => 'ca2222',
+          :cert_ext      => '.pem',
+          :key_ext       => '.pem',
+          :ca_ext        => '.pem',
+          :chain_ext     => '.pem',
+        }
+      }
+
+      it { should contain_file('/etc/ssl/certs/base.example.org.pem') }
+      it { should contain_file('/etc/ssl/private/base.example.org.pem') }
+      it { should contain_file('/etc/ssl/certs/ca.pem') }
+      it { should contain_file('/etc/ssl/certs/chain.pem') }
+    end
+  end
+end


### PR DESCRIPTION
* Add .rspec for better test output
* Add the ability to pass certificate/key data in as "content"
* Add "ensure" to certs::site so that we can remove certs/keys as well
* Fix bug with service notification code
* Add beginning spec tests for certs::site
* Fix cert/key source issue, and add placeholder to site spec
* Add the ability to add chain or ca by content
* Add SPEC tests for ca/chain files
* Add SPEC tests for merging certificate with chain/ca
* Add lots more tests