### PR TITLE
merge_key and SPEC updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -322,10 +322,15 @@ Option to merge the intermediate chain into the actual certificate file, which i
 
 Optional value. **Default: false.**
 
+##### `merge_key`
+Option to merge the private key into the actual certificate file, which is required by some software.
+
+Optional value. **Default: false.**
+
 ## Limitations
 
 This module is CI tested against [open source Puppet](https://docs.puppetlabs.com/puppet) on:
-- CentOS 5 and 6
+- CentOS 5, 6, and 7
 - RHEL 5, 6, and 7
 
 This module also provides functions for other distributions and operating systems, such as FreeBSD and Gentoo, but is not formally tested on them and are subject to regressions.
@@ -334,7 +339,17 @@ No issues have been identified as of yet.
 
 ## Release Notes
 
+### 1.1.0 (January 17, 2017)
+
+#### Summary
+* Introducing an option to merge the private key into certificates for services that require it
+* Update spec replacing `should` with `is_expected.to` for all tests
+
+#### Features
+* The `merge_key` parameter has been added to support merging private keys with certificates when required.
+
 ### 1.0.0 (September 6, 2016)
+
 #### Summary
 * Introducing new features, primarily an option to merge certificates for services that require it
 * Adding Vagrant support for testing using Puppet 4

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "broadinstitute-certs",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "author": [
     "Riccardo Calixte <rcalixte@broadinstitute.org>",
     "Andrew Teixeira <teixeira@broadinstitute.org"

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -17,7 +17,7 @@ describe 'certs', :type => :class do
         } }
 
         context 'with defaults for all parameters' do
-          it { should contain_class('certs') }
+          it { is_expected.to contain_class('certs') }
         end
       end
 
@@ -30,7 +30,7 @@ describe 'certs', :type => :class do
         } }
 
         context 'with defaults for all parameters' do
-          it { should contain_class('certs') }
+          it { is_expected.to contain_class('certs') }
         end
 
       end
@@ -43,7 +43,7 @@ describe 'certs', :type => :class do
         } }
 
         context 'with defaults for all parameters' do
-          it { should contain_class('certs') }
+          it { is_expected.to contain_class('certs') }
         end
 
       end
@@ -57,7 +57,7 @@ describe 'certs', :type => :class do
         } }
 
         context 'with defaults for all parameters' do
-          it { should contain_class('certs') }
+          it { is_expected.to contain_class('certs') }
         end
       end
 

--- a/spec/defines/site_spec.rb
+++ b/spec/defines/site_spec.rb
@@ -30,10 +30,10 @@ describe 'certs::site', :type => :define do
             }
           }
 
-          it { should contain_file('/etc/ssl/certs').with_ensure('directory') }
-          it { should contain_file('/etc/ssl/private').with_ensure('directory') }
-          it { should contain_file('/etc/ssl/certs/base.example.org.crt').with_group('root') }
-          it { should contain_file('/etc/ssl/private/base.example.org.key').with_group('root') }
+          it { is_expected.to contain_file('/etc/ssl/certs').with_ensure('directory') }
+          it { is_expected.to contain_file('/etc/ssl/private').with_ensure('directory') }
+          it { is_expected.to contain_file('/etc/ssl/certs/base.example.org.crt').with_group('root') }
+          it { is_expected.to contain_file('/etc/ssl/private/base.example.org.key').with_group('root') }
         end
 
       end
@@ -55,10 +55,10 @@ describe 'certs::site', :type => :define do
             }
           }
 
-          it { should contain_file('/usr/local/etc/apache24').with_ensure('directory') }
-          it { should contain_file('/usr/local/etc/apache24').with_group('wheel') }
-          it { should contain_file('/usr/local/etc/apache24/base.example.org.crt').with_group('wheel') }
-          it { should contain_file('/usr/local/etc/apache24/base.example.org.key').with_group('wheel') }
+          it { is_expected.to contain_file('/usr/local/etc/apache24').with_ensure('directory') }
+          it { is_expected.to contain_file('/usr/local/etc/apache24').with_group('wheel') }
+          it { is_expected.to contain_file('/usr/local/etc/apache24/base.example.org.crt').with_group('wheel') }
+          it { is_expected.to contain_file('/usr/local/etc/apache24/base.example.org.key').with_group('wheel') }
         end
 
       end
@@ -79,10 +79,10 @@ describe 'certs::site', :type => :define do
             }
           }
 
-          it { should contain_file('/etc/ssl/apache2').with_ensure('directory') }
-          it { should contain_file('/etc/ssl/apache2').with_group('wheel') }
-          it { should contain_file('/etc/ssl/apache2/base.example.org.crt').with_group('wheel') }
-          it { should contain_file('/etc/ssl/apache2/base.example.org.key').with_group('wheel') }
+          it { is_expected.to contain_file('/etc/ssl/apache2').with_ensure('directory') }
+          it { is_expected.to contain_file('/etc/ssl/apache2').with_group('wheel') }
+          it { is_expected.to contain_file('/etc/ssl/apache2/base.example.org.crt').with_group('wheel') }
+          it { is_expected.to contain_file('/etc/ssl/apache2/base.example.org.key').with_group('wheel') }
         end
 
       end
@@ -104,10 +104,10 @@ describe 'certs::site', :type => :define do
             }
           }
 
-          it { should contain_file('/etc/pki/tls/certs').with_ensure('directory') }
-          it { should contain_file('/etc/pki/tls/private').with_ensure('directory') }
-          it { should contain_file('/etc/pki/tls/certs/base.example.org.crt').with_group('root') }
-          it { should contain_file('/etc/pki/tls/private/base.example.org.key').with_group('root') }
+          it { is_expected.to contain_file('/etc/pki/tls/certs').with_ensure('directory') }
+          it { is_expected.to contain_file('/etc/pki/tls/private').with_ensure('directory') }
+          it { is_expected.to contain_file('/etc/pki/tls/certs/base.example.org.crt').with_group('root') }
+          it { is_expected.to contain_file('/etc/pki/tls/private/base.example.org.key').with_group('root') }
         end
 
       end
@@ -142,8 +142,8 @@ describe 'certs::site', :type => :define do
         }
       }
 
-      it { should contain_file('/etc/ssl/certs/base.example.org.crt').with_content(/cert1111/) }
-      it { should contain_file('/etc/ssl/private/base.example.org.key').with_content(/key1111/) }
+      it { is_expected.to contain_file('/etc/ssl/certs/base.example.org.crt').with_content(/cert1111/) }
+      it { is_expected.to contain_file('/etc/ssl/private/base.example.org.key').with_content(/key1111/) }
     end
 
     context 'with ensure => absent' do
@@ -156,8 +156,8 @@ describe 'certs::site', :type => :define do
         }
       }
 
-      it { should contain_file('/etc/ssl/certs/base.example.org.crt').with_ensure('absent') }
-      it { should contain_file('/etc/ssl/private/base.example.org.key').with_ensure('absent') }
+      it { is_expected.to contain_file('/etc/ssl/certs/base.example.org.crt').with_ensure('absent') }
+      it { is_expected.to contain_file('/etc/ssl/private/base.example.org.key').with_ensure('absent') }
     end
 
     context 'with CA cert' do
@@ -173,9 +173,9 @@ describe 'certs::site', :type => :define do
         }
       }
 
-      it { should contain_file('/etc/ssl/certs/base.example.org.crt').with_content(/cert1111/) }
-      it { should contain_file('/etc/ssl/private/base.example.org.key').with_content(/key1111/) }
-      it { should contain_file('/etc/ssl/certs/ca.crt').with_content(/ca2222/) }
+      it { is_expected.to contain_file('/etc/ssl/certs/base.example.org.crt').with_content(/cert1111/) }
+      it { is_expected.to contain_file('/etc/ssl/private/base.example.org.key').with_content(/key1111/) }
+      it { is_expected.to contain_file('/etc/ssl/certs/ca.crt').with_content(/ca2222/) }
     end
 
     context 'with chain cert' do
@@ -191,9 +191,9 @@ describe 'certs::site', :type => :define do
         }
       }
 
-      it { should contain_file('/etc/ssl/certs/base.example.org.crt').with_content(/cert1111/) }
-      it { should contain_file('/etc/ssl/private/base.example.org.key').with_content(/key1111/) }
-      it { should contain_file('/etc/ssl/certs/chain.crt').with_content(/chain3333/) }
+      it { is_expected.to contain_file('/etc/ssl/certs/base.example.org.crt').with_content(/cert1111/) }
+      it { is_expected.to contain_file('/etc/ssl/private/base.example.org.key').with_content(/key1111/) }
+      it { is_expected.to contain_file('/etc/ssl/certs/chain.crt').with_content(/chain3333/) }
     end
 
     context 'with merge_chain set to true with CA' do
@@ -210,17 +210,17 @@ describe 'certs::site', :type => :define do
         }
       }
 
-      it { should contain_concat('base.example.org_cert_merged') }
+      it { is_expected.to contain_concat('base.example.org_cert_merged') }
       it {
-        should contain_concat__fragment('base.example.org.crt_certificate').with(
+        is_expected.to contain_concat__fragment('base.example.org.crt_certificate').with(
           :content => /cert1111/ )
       }
       it {
-        should contain_concat__fragment('base.example.org.crt_ca').with(
+        is_expected.to contain_concat__fragment('base.example.org.crt_ca').with(
           :content => /ca2222/ )
       }
-      it { should contain_file('/etc/ssl/private/base.example.org.key').with_content(/key1111/) }
-      it { should contain_file('/etc/ssl/certs/ca.crt').with_content(/ca2222/) }
+      it { is_expected.to contain_file('/etc/ssl/private/base.example.org.key').with_content(/key1111/) }
+      it { is_expected.to contain_file('/etc/ssl/certs/ca.crt').with_content(/ca2222/) }
     end
 
     context 'with merge_chain set to true with chain' do
@@ -237,17 +237,17 @@ describe 'certs::site', :type => :define do
         }
       }
 
-      it { should contain_concat('base.example.org_cert_merged') }
+      it { is_expected.to contain_concat('base.example.org_cert_merged') }
       it {
-        should contain_concat__fragment('base.example.org.crt_certificate').with(
+        is_expected.to contain_concat__fragment('base.example.org.crt_certificate').with(
           :content => /cert1111/ )
       }
       it {
-        should contain_concat__fragment('base.example.org.crt_chain').with(
+        is_expected.to contain_concat__fragment('base.example.org.crt_chain').with(
           :content => /chain3333/ )
       }
-      it { should contain_file('/etc/ssl/private/base.example.org.key').with_content(/key1111/) }
-      it { should contain_file('/etc/ssl/certs/chain.crt').with_content(/chain3333/) }
+      it { is_expected.to contain_file('/etc/ssl/private/base.example.org.key').with_content(/key1111/) }
+      it { is_expected.to contain_file('/etc/ssl/certs/chain.crt').with_content(/chain3333/) }
     end
 
     context 'with merge_chain set to true with CA and chain' do
@@ -267,22 +267,162 @@ describe 'certs::site', :type => :define do
         }
       }
 
-      it { should contain_concat('base.example.org_cert_merged') }
+      it { is_expected.to contain_concat('base.example.org_cert_merged') }
       it {
-        should contain_concat__fragment('base.example.org.crt_certificate').with(
+        is_expected.to contain_concat__fragment('base.example.org.crt_certificate').with(
           :content => /cert1111/ )
       }
       it {
-        should contain_concat__fragment('base.example.org.crt_ca').with(
+        is_expected.to contain_concat__fragment('base.example.org.crt_ca').with(
           :content => /ca2222/ )
       }
       it {
-        should contain_concat__fragment('base.example.org.crt_chain').with(
+        is_expected.to contain_concat__fragment('base.example.org.crt_chain').with(
           :content => /chain3333/ )
       }
-      it { should contain_file('/etc/ssl/private/base.example.org.key').with_content(/key1111/) }
-      it { should contain_file('/etc/ssl/certs/ca.crt').with_content(/ca2222/) }
-      it { should contain_file('/etc/ssl/certs/chain.crt').with_content(/chain3333/) }
+      it { is_expected.to contain_file('/etc/ssl/private/base.example.org.key').with_content(/key1111/) }
+      it { is_expected.to contain_file('/etc/ssl/certs/ca.crt').with_content(/ca2222/) }
+      it { is_expected.to contain_file('/etc/ssl/certs/chain.crt').with_content(/chain3333/) }
+    end
+
+    context 'with merge_chain set to false and merge_key set to true with neither chain nor CA' do
+      let(:params) {
+        {
+          :cert_content  => 'cert1111',
+          :key_content   => 'key1111',
+          :service       => :undef,
+          :ensure        => 'present',
+          :merge_chain   => false,
+          :merge_key     => true
+        }
+      }
+
+      it { is_expected.to contain_concat('base.example.org_cert_merged') }
+      it {
+        is_expected.to contain_concat__fragment('base.example.org.crt_certificate').with(
+          :content => /cert1111/ )
+      }
+      it {
+        is_expected.to contain_concat__fragment('base.example.org.crt_key').with(
+          :content => /key1111/ )
+      }
+      it {
+        is_expected.not_to contain_concat__fragment('base.example.org.crt_ca')
+      }
+      it {
+        is_expected.not_to contain_concat__fragment('base.example.org.crt_chain')
+      }
+      it { is_expected.to contain_file('/etc/ssl/private/base.example.org.key').with_content(/key1111/) }
+    end
+
+    context 'with merge_chain set to false and merge_key set to true with chain and CA set' do
+      let(:params) {
+        {
+          :cert_content  => 'cert1111',
+          :key_content   => 'key1111',
+          :service       => :undef,
+          :ensure        => 'present',
+          :cert_chain    => true,
+          :chain_name    => 'chain',
+          :chain_content => 'chain3333',
+          :ca_cert       => true,
+          :ca_name       => 'ca',
+          :ca_content    => 'ca2222',
+          :merge_chain   => false,
+          :merge_key     => true
+        }
+      }
+
+      it { is_expected.to contain_concat('base.example.org_cert_merged') }
+      it {
+        is_expected.to contain_concat__fragment('base.example.org.crt_certificate').with(
+          :content => /cert1111/ )
+      }
+      it {
+        is_expected.to contain_concat__fragment('base.example.org.crt_key').with(
+          :content => /key1111/ )
+      }
+      it {
+        is_expected.not_to contain_concat__fragment('base.example.org.crt_ca')
+      }
+      it {
+        is_expected.not_to contain_concat__fragment('base.example.org.crt_chain')
+      }
+      it { is_expected.to contain_file('/etc/ssl/private/base.example.org.key').with_content(/key1111/) }
+      it { is_expected.to contain_file('/etc/ssl/certs/ca.crt').with_content(/ca2222/) }
+      it { is_expected.to contain_file('/etc/ssl/certs/chain.crt').with_content(/chain3333/) }
+    end
+
+    context 'with merge_chain and merge_key set to true with chain' do
+      let(:params) {
+        {
+          :cert_content  => 'cert1111',
+          :key_content   => 'key1111',
+          :service       => :undef,
+          :ensure        => 'present',
+          :cert_chain    => true,
+          :chain_name    => 'chain',
+          :chain_content => 'chain3333',
+          :merge_chain   => true,
+          :merge_key     => true
+        }
+      }
+
+      it { is_expected.to contain_concat('base.example.org_cert_merged') }
+      it {
+        is_expected.to contain_concat__fragment('base.example.org.crt_certificate').with(
+          :content => /cert1111/ )
+      }
+      it {
+        is_expected.to contain_concat__fragment('base.example.org.crt_key').with(
+          :content => /key1111/ )
+      }
+      it {
+        is_expected.to contain_concat__fragment('base.example.org.crt_chain').with(
+          :content => /chain3333/ )
+      }
+      it { is_expected.to contain_file('/etc/ssl/private/base.example.org.key').with_content(/key1111/) }
+      it { is_expected.to contain_file('/etc/ssl/certs/chain.crt').with_content(/chain3333/) }
+    end
+
+    context 'with merge_chain and merge_key set to true with CA and chain' do
+      let(:params) {
+        {
+          :cert_content  => 'cert1111',
+          :key_content   => 'key1111',
+          :service       => :undef,
+          :ensure        => 'present',
+          :cert_chain    => true,
+          :chain_name    => 'chain',
+          :chain_content => 'chain3333',
+          :ca_cert       => true,
+          :ca_name       => 'ca',
+          :ca_content    => 'ca2222',
+          :merge_chain   => true,
+          :merge_key     => true
+        }
+      }
+
+      it { is_expected.to contain_concat('base.example.org_cert_merged') }
+      it {
+        is_expected.to contain_concat__fragment('base.example.org.crt_certificate').with(
+          :content => /cert1111/ )
+      }
+      it {
+        is_expected.to contain_concat__fragment('base.example.org.crt_key').with(
+          :content => /key1111/ )
+      }
+      it {
+        is_expected.to contain_concat__fragment('base.example.org.crt_ca').with(
+          :content => /ca2222/ )
+      }
+      it {
+        is_expected.to contain_concat__fragment('base.example.org.crt_chain').with(
+          :content => /chain3333/ )
+      }
+      it { is_expected.to contain_file('/etc/ssl/private/base.example.org.key').with_content(/key1111/) }
+      it { is_expected.to contain_file('/etc/ssl/certs/ca.crt').with_content(/ca2222/) }
+      it { is_expected.to contain_file('/etc/ssl/certs/chain.crt').with_content(/chain3333/) }
     end
 
     context 'with a custom user set' do
@@ -302,10 +442,10 @@ describe 'certs::site', :type => :define do
         }
       }
 
-      it { should contain_file('/etc/ssl/certs/base.example.org.crt').with_owner('newowner') }
-      it { should contain_file('/etc/ssl/private/base.example.org.key').with_owner('newowner') }
-      it { should contain_file('/etc/ssl/certs/ca.crt').with_owner('newowner') }
-      it { should contain_file('/etc/ssl/certs/chain.crt').with_owner('newowner') }
+      it { is_expected.to contain_file('/etc/ssl/certs/base.example.org.crt').with_owner('newowner') }
+      it { is_expected.to contain_file('/etc/ssl/private/base.example.org.key').with_owner('newowner') }
+      it { is_expected.to contain_file('/etc/ssl/certs/ca.crt').with_owner('newowner') }
+      it { is_expected.to contain_file('/etc/ssl/certs/chain.crt').with_owner('newowner') }
     end
 
     context 'with a custom group set' do
@@ -325,10 +465,10 @@ describe 'certs::site', :type => :define do
         }
       }
 
-      it { should contain_file('/etc/ssl/certs/base.example.org.crt').with_group('newgroup') }
-      it { should contain_file('/etc/ssl/private/base.example.org.key').with_group('newgroup') }
-      it { should contain_file('/etc/ssl/certs/ca.crt').with_group('newgroup') }
-      it { should contain_file('/etc/ssl/certs/chain.crt').with_group('newgroup') }
+      it { is_expected.to contain_file('/etc/ssl/certs/base.example.org.crt').with_group('newgroup') }
+      it { is_expected.to contain_file('/etc/ssl/private/base.example.org.key').with_group('newgroup') }
+      it { is_expected.to contain_file('/etc/ssl/certs/ca.crt').with_group('newgroup') }
+      it { is_expected.to contain_file('/etc/ssl/certs/chain.crt').with_group('newgroup') }
     end
 
     context 'with a custom file and directory modes set' do
@@ -351,15 +491,15 @@ describe 'certs::site', :type => :define do
         }
       }
 
-      it { should contain_file('/etc/ssl/certs').with_ensure('directory') }
-      it { should contain_file('/etc/ssl/certs').with_mode('0500') }
-      it { should contain_file('/etc/ssl/private').with_ensure('directory') }
-      it { should contain_file('/etc/ssl/private').with_mode('0500') }
+      it { is_expected.to contain_file('/etc/ssl/certs').with_ensure('directory') }
+      it { is_expected.to contain_file('/etc/ssl/certs').with_mode('0500') }
+      it { is_expected.to contain_file('/etc/ssl/private').with_ensure('directory') }
+      it { is_expected.to contain_file('/etc/ssl/private').with_mode('0500') }
 
-      it { should contain_file('/etc/ssl/certs/base.example.org.crt').with_mode('0700') }
-      it { should contain_file('/etc/ssl/private/base.example.org.key').with_mode('0400') }
-      it { should contain_file('/etc/ssl/certs/ca.crt').with_mode('0700') }
-      it { should contain_file('/etc/ssl/certs/chain.crt').with_mode('0700') }
+      it { is_expected.to contain_file('/etc/ssl/certs/base.example.org.crt').with_mode('0700') }
+      it { is_expected.to contain_file('/etc/ssl/private/base.example.org.key').with_mode('0400') }
+      it { is_expected.to contain_file('/etc/ssl/certs/ca.crt').with_mode('0700') }
+      it { is_expected.to contain_file('/etc/ssl/certs/chain.crt').with_mode('0700') }
     end
 
     context 'with custom extensions set' do
@@ -382,10 +522,10 @@ describe 'certs::site', :type => :define do
         }
       }
 
-      it { should contain_file('/etc/ssl/certs/base.example.org.pem') }
-      it { should contain_file('/etc/ssl/private/base.example.org.pem') }
-      it { should contain_file('/etc/ssl/certs/ca.pem') }
-      it { should contain_file('/etc/ssl/certs/chain.pem') }
+      it { is_expected.to contain_file('/etc/ssl/certs/base.example.org.pem') }
+      it { is_expected.to contain_file('/etc/ssl/private/base.example.org.pem') }
+      it { is_expected.to contain_file('/etc/ssl/certs/ca.pem') }
+      it { is_expected.to contain_file('/etc/ssl/certs/chain.pem') }
     end
   end
 end


### PR DESCRIPTION
Add the ability to merge keys, change "should" to "is_expected.to" in all tests for newer versions of rspec