### PR TITLE
Add dhparam files as well as other cleanup

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -1,8 +1,12 @@
 fixtures:
-  forge_modules:
-    concat: 'puppetlabs/concat'
-    stdlib:
-      repo: 'puppetlabs/stdlib'
-      ref: '4.12.0'
-  symlinks:
-    certs: "#{source_dir}"
+    forge_modules:
+        concat:
+            # Lock at 2.2.1 for Puppet 3
+            repo: 'puppetlabs/concat'
+            ref: '2.2.1'
+        stdlib:
+            # Lock at 4.13.0 for Puppet 3
+            repo: 'puppetlabs/stdlib'
+            ref: '4.13.0'
+    symlinks:
+        certs: "#{source_dir}"

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,9 +18,9 @@ matrix:
   include:
   - rvm: 2.1.9
     env: PUPPET_GEM_VERSION="~> 4.0" STRICT_VARIABLES="yes"
-  - rvm: 2.1.5
+  - rvm: 2.0
     env: PUPPET_GEM_VERSION="~> 3.0" FUTURE_PARSER="yes"
-  - rvm: 2.1.5
+  - rvm: 2.0
     env: PUPPET_GEM_VERSION="~> 3.0"
   - rvm: 2.2
     env: PUPPET_GEM_VERSION="~> 4.0" STRICT_VARIABLES="yes"

--- a/README.md
+++ b/README.md
@@ -183,20 +183,62 @@ The `certs::site` defined type allows you to define certificates to deploy to ma
 
 #### Parameters within `certs::site`
 
-##### `name`
-The title of the resource matches the certificate's name
+##### `ca_cert`
+Boolean for whether to look for a CA certificate file.
 
-e.g. 'www.example.com' matches the certificate for the hostname 'www.example.com'
+Optional value. **Default: false**.
 
-##### `source_path`
-The location of the certificate files. Typically references a module's files.
+##### `ca_content`
+A string representing the contents of the CA file.
 
-e.g. *'puppet:///site_certs'* will search for the mount point defined in `fileserver.conf` on the Puppet Server for the specified files.
+Optional value. **Default: undef**.
+
+##### `ca_ext`
+The extension of the CA certificate file.
+
+Optional value. **Default: crt**.
+
+##### `ca_name`
+The name of the CA certificate file.
+
+Optional value. **Default: undef**.
+
+##### `ca_path`
+Location where the CA certificate file will be stored on the managed node.
+
+Optional value. **Default: `cert_path`**.
+
+##### `ca_source_path`
+The location of the CA certificate file. Typically references a module's files.
+
+e.g. *'puppet:///ca_certs'* will search for the mount point defined in `fileserver.conf` on the Puppet Server for the specified files.
+
+Optional value. **Default: `source_path`**.
+
+##### `cert_chain`
+Boolean for whether to look for a certificate chain file.
+
+Optional value. **Default: false**.
+
+##### `cert_content`
+A string representing the contents of the certificate file.  This can only be provided if `$source_path` is undefined or an error will occur.
+
+Optional value. **Default: undef**.
+
+##### `cert_dir_mode`
+Permissions of the certificate directory.
+
+Optional value. **Default: '0755'**.
 
 ##### `cert_ext`
 The extension of the certificate file.
 
-Optional value. **Default: '.crt'.**
+Optional value. **Default: '.crt'**.
+
+##### `cert_mode`
+Permissions of the certificate files.
+
+Optional value. **Default: '0644'**.
 
 ##### `cert_path`
 Location where the certificate files will be stored on the managed node.
@@ -207,10 +249,79 @@ Optional value. Defaults:
   - **FreeBSD**: `/usr/local/etc/apache24`
   - **Gentoo**: `/etc/ssl/apache2`
 
+##### `chain_content`
+A string representing the contents of the chain file.
+
+Optional value. Default: **undef**.
+
+##### `chain_ext`
+The extension of the certificate chain file.
+
+Optional value. **Default: crt**.
+
+##### `chain_name`
+The name of the certificate chain file.
+
+Optional value. **Default: undef**.
+
+##### `chain_path`
+Location where the certificate chain file will be stored on the managed node.
+
+Optional value. **Default: `cert_path`**.
+
+##### `chain_source_path`
+The location of the certificate chain file. Typically references a module's files.
+
+e.g. *'puppet:///chain_certs'* will search for the mount point defined in `fileserver.conf` on the Puppet Server for the specified files.
+
+Optional value. **Default: `source_path`**.
+
+##### `dhparam`
+A boolean value to determine whether a dhparam file should be placed on the system along with the other certificate files.  The dhparam file will need to exist on the source side just as with the other certificate files in order for the file to be delivered.
+
+Optional value. **Default: false**.
+
+##### `dhparam_content`
+A string representing the contents of the dhparam file.  This option will take precedence over dhparam_file if it exists on the source side.
+
+Optional value. **Default: undef**.
+
+##### `dhparam_file`
+The name of the dhparam file.
+
+Optional value. **Default: 'dh2048.pem'**.
+
+##### `ensure`
+Ensure for the site resources.  If `present`, files will be put in place.  If `absent`, certificate, key and dhparam files will be removed.
+
+Optional value. **Default: 'present'**.
+
+##### `group`
+Name of the group owner of the certificates.
+
+Optional value. Defaults:
+  - **RedHat**, **Debian**, and **SuSE**: `root`
+  - **FreeBSD** and **Gentoo**: `wheel`
+
+##### `key_content`
+A string representing the contents of the key file.  This can only be provided if `$source_path` is undefined or an error will occur.
+
+Optional value. **Default: undef**.
+
+##### `key_dir_mode`
+Permissions of the private keys directory.
+
+Optional value. **Default: '0755'**.
+
 ##### `key_ext`
 The extension of the private key file.
 
-Optional value. **Default: '.key'.**
+Optional value. **Default: '.key'**.
+
+##### `key_mode`
+Permissions of the private keys.
+
+Optional value. **Default: '0600'**.
 
 ##### `key_path`
 Location where the private keys will be stored on the managed node.
@@ -221,59 +332,25 @@ Optional value. Defaults:
   - **FreeBSD**: `/usr/local/etc/apache24`
   - **Gentoo**: `/etc/ssl/apache2`
 
-##### `cert_chain`
-Boolean for whether to look for a certificate chain file.
+##### `merge_chain`
+Option to merge the CA and intermediate chain files into the actual certificate file, which is required by some software.
 
-Optional value. **Default: false.**
+Optional value. **Default: false**.
 
-##### `chain_name`
-The name of the certificate chain file.
+##### `merge_key`
+Option to merge the private key into the actual certificate file, which is required by some software.
 
-Optional value. **Default: undef.**
+Optional value. **Default: false**.
 
-##### `chain_ext`
-The extension of the certificate chain file.
+##### `name`
+The title of the resource matches the certificate's name
 
-Optional value. **Default: crt.**
+e.g. **www.example.com** matches the certificate for the hostname **www.example.com**.
 
-##### `chain_path`
-Location where the certificate chain file will be stored on the managed node.
+##### `owner`
+Name of the owner of the certificates.
 
-Optional value. **Default: `cert_path`.**
-
-##### `chain_source_path`
-The location of the certificate chain file. Typically references a module's files.
-
-e.g. *'puppet:///chain_certs'* will search for the mount point defined in `fileserver.conf` on the Puppet Server for the specified files.
-
-Optional value. **Default: `source_path`.**
-
-##### `ca_cert`
-Boolean for whether to look for a CA certificate file.
-
-Optional value. **Default: false.**
-
-##### `ca_name`
-The name of the CA certificate file.
-
-Optional value. **Default: undef.**
-
-##### `ca_ext`
-The extension of the CA certificate file.
-
-Optional value. **Default: crt.**
-
-##### `ca_path`
-Location where the CA certificate file will be stored on the managed node.
-
-Optional value. **Default: `cert_path`.**
-
-##### `ca_source_path`
-The location of the CA certificate file. Typically references a module's files.
-
-e.g. *'puppet:///ca_certs'* will search for the mount point defined in `fileserver.conf` on the Puppet Server for the specified files.
-
-Optional value. **Default: `source_path`.**
+Optional value. **Default: 'root'**.
 
 ##### `service`
 Name of the server service to notify when certificates are updated.
@@ -285,47 +362,10 @@ Optional value. Defaults:
    - **Debian**, **SuSE**, and **Gentoo**: `apache2`
    - **FreeBSD**: `apache24`
 
-##### `owner`
-Name of the owner of the certificates.
+##### `source_path`
+The location of the certificate files. Typically references a module's files.
 
-Optional value. **Default: 'root'.**
-
-##### `group`
-Name of the group owner of the certificates.
-
-Optional value. Defaults:
-  - **RedHat**, **Debian**, and **SuSE**: `root`
-  - **FreeBSD** and **Gentoo**: `wheel`
-
-##### `cert_mode`
-Permissions of the certificate files.
-
-Optional value. **Default: '0644'.**
-
-##### `key_mode`
-Permissions of the private keys.
-
-Optional value. **Default: '0600'.**
-
-##### `cert_dir_mode`
-Permissions of the certificate directory.
-
-Optional value. **Default: '0755'.**
-
-##### `key_dir_mode`
-Permissions of the private keys directory.
-
-Optional value. **Default: '0755'.**
-
-##### `merge_chain`
-Option to merge the intermediate chain into the actual certificate file, which is required by some software.
-
-Optional value. **Default: false.**
-
-##### `merge_key`
-Option to merge the private key into the actual certificate file, which is required by some software.
-
-Optional value. **Default: false.**
+e.g. *'puppet:///site_certs'* will search for the mount point defined in `fileserver.conf` on the Puppet Server for the specified files.
 
 ## Limitations
 

--- a/Rakefile
+++ b/Rakefile
@@ -7,10 +7,10 @@ require 'puppet/version'
 require 'puppetlabs_spec_helper/rake_tasks'
 
 exclude_paths = [
-  "bundle/**/*",
-  "pkg/**/*",
-  "vendor/**/*",
-  "spec/**/*",
+    "bundle/**/*",
+    "pkg/**/*",
+    "vendor/**/*",
+    "spec/**/*",
 ]
 
 Rake::Task[:lint].clear
@@ -36,19 +36,28 @@ PuppetSyntax.exclude_paths = exclude_paths
 # These two gems aren't always present, for instance
 # on Travis with --without development
 
+# Prevent fixtures from being deleted on each successful run by cutting out
+# the spec_clean task
+# https://projects.puppetlabs.com/issues/20013
+Rake::Task[:spec].clear
+task :spec do
+    Rake::Task[:spec_prep].invoke
+    Rake::Task[:spec_standalone].invoke
+end
+
 begin
-  require 'puppet_blacksmith/rake_tasks'
+    require 'puppet_blacksmith/rake_tasks'
 rescue LoadError
 end
 
 task :metadata_lint do
-  sh "bundle exec metadata-json-lint metadata.json"
+    sh "bundle exec metadata-json-lint metadata.json"
 end
 
 desc "Run syntax, lint, and spec tests."
 task :test => [
-  :syntax,
-  :lint,
-  :spec,
-  :metadata_lint,
+    :syntax,
+    :lint,
+    :spec,
+    :metadata_lint,
 ]

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -12,66 +12,167 @@
 #
 # Copyright 2016
 #
+# === Parameters
+#
+# [ca_ext]
+# The extension of the CA certificate file.
+# This sets the default globally for use by all certs::site resources.
+# Optional value. Default: crt.
+#
+# [ca_path]
+# Location where the CA certificate file will be stored on the managed node.
+# This sets the default globally for use by all certs::site resources.
+# Optional value. Default: [cert_path].
+#
+# [cert_dir_mode]
+# Permissions of the certificate directory.
+# This sets the default globally for use by all certs::site resources.
+# Optional value. Default: '0755'.
+#
+# [cert_ext]
+# The extension of the certificate file.
+# This sets the default globally for use by all certs::site resources.
+# Optional value. Default: '.crt'.
+#
+# [cert_mode]
+# Permissions of the certificate files.
+# This sets the default globally for use by all certs::site resources.
+# Optional value. Default: '0644'.
+#
+# [cert_path]
+# Location where the certificate files will be stored on the managed node.
+# This sets the default globally for use by all certs::site resources.
+# Optional value. Defaults:
+#   - '/etc/pki/tls/certs' on RedHat-based systems
+#   - '/etc/ssl/certs' on Debian-based and Suse-based systems
+#   - '/usr/local/etc/apache24' on FreeBSD-based systems
+#   - '/etc/ssl/apache2' on Gentoo-based systems
+#
+# [chain_ext]
+# The extension of the certificate chain file.
+# This sets the default globally for use by all certs::site resources.
+# Optional value. Default: crt.
+#
+# [chain_path]
+# Location where the certificate chain file will be stored on the managed node.
+# This sets the default globally for use by all certs::site resources.
+# Optional value. Default: [cert_path].
+#
+# [dhparam_file]
+# The name of the dhparam file.
+# This sets the default globally for use by all certs::site resources.
+# Optional value. Default: 'dh2048.pem'.
+#
+# [group]
+# Name of the group owner of the certificates.
+# This sets the default globally for use by all certs::site resources.
+# Optional value. Defaults:
+#   - 'root' for Redhat-based, Debian-based, and Suse-based systems
+#   - 'wheel' for FreeBSD and Gentoo-based systems
+#
+# [key_dir_mode]
+# Permissions of the private keys directory.
+# This sets the default globally for use by all certs::site resources.
+# Optional value. Default: '0755'.
+#
+# [key_ext]
+# The extension of the private key file.
+# This sets the default globally for use by all certs::site resources.
+# Optional value. Default: '.key'.
+#
+# [key_mode]
+# Permissions of the private keys.
+# This sets the default globally for use by all certs::site resources.
+# Optional value. Default: '0600'.
+#
+# [key_path]
+# Location where the private keys will be stored on the managed node.
+# This sets the default globally for use by all certs::site resources.
+# Optional value. Defaults:
+#   - '/etc/pki/tls/private' on RedHat-based systems
+#   - '/etc/ssl/private' on Debian-based and Suse-based systems
+#   - '/usr/local/etc/apache24' on FreeBSD-based systems
+#   - '/etc/ssl/apache2' on Gentoo-based systems
+#
+# [owner]
+# Name of the owner of the certificates.
+# This sets the default globally for use by all certs::site resources.
+# Optional value. Default: 'root'.
+#
+# [service]
+# Name of the server service to notify when certificates are updated.
+# Setting to `undef` will disable service notifications.
+# This sets the default globally for use by all certs::site resources.
+# Optional value. Defaults:
+#   - 'httpd' for RedHat-based systems
+#   - 'apache2' for Debian-based, Suse-based, and Gentoo-based systems
+#   - 'apache24' for FreeBSD-based systems
+#
+# [sites]
+# A hash of certs::site configurations, typically provided by Hiera.
+# Optional value: Default: {}
+#
 class certs (
-  $cert_ext      = undef,
-  $cert_path     = undef,
-  $key_ext       = undef,
-  $key_path      = undef,
-  $chain_ext     = undef,
-  $chain_path    = undef,
-  $ca_ext        = undef,
-  $ca_path       = undef,
-  $service       = undef,
-  $owner         = undef,
-  $group         = undef,
-  $cert_mode     = undef,
-  $key_mode      = undef,
-  $cert_dir_mode = undef,
-  $key_dir_mode  = undef,
-  $sites         = hiera_hash('certs::sites', {}),
+    $ca_ext        = undef,
+    $ca_path       = undef,
+    $cert_dir_mode = undef,
+    $cert_ext      = undef,
+    $cert_mode     = undef,
+    $cert_path     = undef,
+    $chain_ext     = undef,
+    $chain_path    = undef,
+    $dhparam_file  = undef,
+    $group         = undef,
+    $key_dir_mode  = undef,
+    $key_ext       = undef,
+    $key_mode      = undef,
+    $key_path      = undef,
+    $owner         = undef,
+    $service       = undef,
+    $sites         = hiera_hash('certs::sites', {}),
 ) {
 
-  include ::certs::params
+    include ::certs::params
 
-  $_cert_ext      = pick_default($cert_ext, $::certs::params::cert_ext)
-  $_cert_path     = pick_default($cert_path, $::certs::params::cert_path)
-  $_key_ext       = pick_default($key_ext, $::certs::params::key_ext)
-  $_key_path      = pick_default($key_path, $::certs::params::key_path)
-  $_chain_ext     = pick_default($chain_ext, $::certs::params::chain_ext)
-  $_chain_path    = pick_default($chain_path, $::certs::params::chain_path)
-  $_ca_ext        = pick_default($ca_ext, $::certs::params::ca_ext)
-  $_ca_path       = pick_default($ca_path, $::certs::params::ca_path)
-  $_service       = pick_default($service, $::certs::params::service)
-  $_owner         = pick_default($owner, $::certs::params::owner)
-  $_group         = pick_default($group, $::certs::params::group)
-  $_cert_mode     = pick_default($cert_mode, $::certs::params::cert_mode)
-  $_key_mode      = pick_default($key_mode, $::certs::params::key_mode)
-  $_cert_dir_mode = pick_default($cert_dir_mode, $::certs::params::cert_dir_mode)
-  $_key_dir_mode  = pick_default($key_dir_mode, $::certs::params::key_dir_mode)
+    $_ca_ext        = pick_default($ca_ext, $::certs::params::ca_ext)
+    $_ca_path       = pick_default($ca_path, $::certs::params::ca_path)
+    $_cert_dir_mode = pick_default($cert_dir_mode, $::certs::params::cert_dir_mode)
+    $_cert_ext      = pick_default($cert_ext, $::certs::params::cert_ext)
+    $_cert_mode     = pick_default($cert_mode, $::certs::params::cert_mode)
+    $_cert_path     = pick_default($cert_path, $::certs::params::cert_path)
+    $_chain_ext     = pick_default($chain_ext, $::certs::params::chain_ext)
+    $_chain_path    = pick_default($chain_path, $::certs::params::chain_path)
+    $_dhparam_file  = pick_default($dhparam_file, $::certs::params::dhparam_file)
+    $_group         = pick_default($group, $::certs::params::group)
+    $_key_dir_mode  = pick_default($key_dir_mode, $::certs::params::key_dir_mode)
+    $_key_ext       = pick_default($key_ext, $::certs::params::key_ext)
+    $_key_mode      = pick_default($key_mode, $::certs::params::key_mode)
+    $_key_path      = pick_default($key_path, $::certs::params::key_path)
+    $_owner         = pick_default($owner, $::certs::params::owner)
+    $_service       = pick_default($service, $::certs::params::service)
 
-  validate_string($_cert_ext)
-  validate_absolute_path($_cert_path)
-  validate_string($_key_ext)
-  validate_absolute_path($_key_path)
-  validate_string($_chain_ext)
-  validate_absolute_path($_chain_path)
-  validate_string($_ca_ext)
-  validate_absolute_path($_ca_path)
+    validate_string($_ca_ext)
+    validate_absolute_path($_ca_path)
+    validate_string($_cert_dir_mode)
+    validate_numeric($_cert_dir_mode)
+    validate_string($_cert_ext)
+    validate_string($_cert_mode)
+    validate_numeric($_cert_mode)
+    validate_absolute_path($_cert_path)
+    validate_string($_chain_ext)
+    validate_absolute_path($_chain_path)
+    validate_string($_group)
+    validate_string($_key_dir_mode)
+    validate_numeric($_key_dir_mode)
+    validate_string($_key_ext)
+    validate_string($_key_mode)
+    validate_numeric($_key_mode)
+    validate_absolute_path($_key_path)
+    validate_string($_owner)
 
-  if $service != undef {
-    validate_string($service)
-  }
+    if $service != undef {
+        validate_string($service)
+    }
 
-  validate_string($_owner)
-  validate_string($_group)
-  validate_string($_cert_mode)
-  validate_numeric($_cert_mode)
-  validate_string($_key_mode)
-  validate_numeric($_key_mode)
-  validate_string($_cert_dir_mode)
-  validate_numeric($_cert_dir_mode)
-  validate_string($_key_dir_mode)
-  validate_numeric($_key_dir_mode)
-
-  create_resources('certs::site', $sites)
+    create_resources('certs::site', $sites)
 }

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -1,164 +1,49 @@
 #
-# === Parameters
-#
-# [name]
-# The title of the resource matches the certificate's name
-# e.g. 'www.example.com' matches the certificate for the hostname
-# 'www.example.com'
-#
-# [source_path]
-# The location of the certificate files. Typically references a module's files.
-# e.g. 'puppet:///site_certs' will search for the mount point defined in the
-# fileserver.conf on the Puppet Server for the specified files.
-#
-# [cert_ext]
-# The extension of the certificate file.
-# Optional value. Default: '.crt'.
-#
-# [cert_path]
-# Location where the certificate files will be stored on the managed node.
-# Optional value. Defaults:
-#   - '/etc/pki/tls/certs' on RedHat-based systems
-#   - '/etc/ssl/certs' on Debian-based and Suse-based systems
-#   - '/usr/local/etc/apache24' on FreeBSD-based systems
-#   - '/etc/ssl/apache2' on Gentoo-based systems
-#
-# [key_ext]
-# The extension of the private key file.
-# Optional value. Default: '.key'.
-#
-# [key_path]
-# Location where the private keys will be stored on the managed node.
-# Optional value. Defaults:
-#   - '/etc/pki/tls/private' on RedHat-based systems
-#   - '/etc/ssl/private' on Debian-based and Suse-based systems
-#   - '/usr/local/etc/apache24' on FreeBSD-based systems
-#   - '/etc/ssl/apache2' on Gentoo-based systems
-#
-# [cert_chain]
-# Boolean for whether to look for a certificate chain file.
-# Optional value. Default: false.
-#
-# [chain_name]
-# The name of the certificate chain file.
-# Optional value. Default: undef.
-#
-# [chain_ext]
-# The extension of the certificate chain file.
-# Optional value. Default: crt.
-#
-# [chain_path]
-# Location where the certificate chain file will be stored on the managed node.
-# Optional value. Default: [cert_path].
-#
-# [chain_source_path]
-# The location of the certificate chain file. Typically references a module's files.
-# e.g. 'puppet:///chain_certs' will search for the mount point defined in the
-# fileserver.conf on the Puppet Server for the specified files.
-# Optional value. Default: [source_path].
-#
-# [ca_cert]
-# Boolean for whether to look for a CA certificate file.
-# Optional value. Default: false.
-#
-# [ca_name]
-# The name of the CA certificate file.
-# Optional value. Default: undef.
-#
-# [ca_ext]
-# The extension of the CA certificate file.
-# Optional value. Default: crt.
-#
-# [ca_path]
-# Location where the CA certificate file will be stored on the managed node.
-# Optional value. Default: [cert_path].
-#
-# [ca_source_path]
-# The location of the CA certificate file. Typically references a module's files.
-# e.g. 'puppet:///ca_certs' will search for the mount point defined in the
-# fileserver.conf on the Puppet Server for the specified files.
-# Optional value. Default: [source_path].
-#
-# [service]
-# Name of the server service to notify when certificates are updated.
-# Setting to `undef` will disable service notifications.
-# Optional value. Defaults:
-#   - 'httpd' for RedHat-based systems
-#   - 'apache2' for Debian-based, Suse-based, and Gentoo-based systems
-#   - 'apache24' for FreeBSD-based systems
-#
-# [owner]
-# Name of the owner of the certificates.
-# Optional value. Default: 'root'.
-#
-# [group]
-# Name of the group owner of the certificates.
-# Optional value. Defaults:
-#   - 'root' for Redhat-based, Debian-based, and Suse-based systems
-#   - 'wheel' for FreeBSD and Gentoo-based systems
-#
-# [cert_mode]
-# Permissions of the certificate files.
-# Optional value. Default: '0644'.
-#
-# [key_mode]
-# Permissions of the private keys.
-# Optional value. Default: '0600'.
-#
-# [cert_dir_mode]
-# Permissions of the certificate directory.
-# Optional value. Default: '0755'.
-#
-# [key_dir_mode]
-# Permissions of the private keys directory.
-# Optional value. Default: '0755'.
-#
-# [merge_chain]
-# Option to merge the intermediate chain into the actual certificate file,
-# which is required by some software.
-# Optional value. Default: false.
+# === Default Parameters
 #
 class certs::params {
-  case $::osfamily {
-    'RedHat': {
-      $cert_path = '/etc/pki/tls/certs'
-      $key_path  = '/etc/pki/tls/private'
-      $service   = 'httpd'
-      $group     = 'root'
+    case $::osfamily {
+        'RedHat': {
+            $cert_path = '/etc/pki/tls/certs'
+            $key_path  = '/etc/pki/tls/private'
+            $service   = 'httpd'
+            $group     = 'root'
+        }
+        'Debian', 'Suse': {
+            $cert_path = '/etc/ssl/certs'
+            $key_path  = '/etc/ssl/private'
+            $service   = 'apache2'
+            $group     = 'root'
+        }
+        'FreeBSD': {
+            $cert_path = '/usr/local/etc/apache24'
+            $key_path  = '/usr/local/etc/apache24'
+            $service   = 'apache24'
+            $group     = 'wheel'
+        }
+        'Gentoo': {
+            $cert_path = '/etc/ssl/apache2'
+            $key_path  = '/etc/ssl/apache2'
+            $service   = 'apache2'
+            $group     = 'wheel'
+        }
+        default: {
+            fail("Class['certs::params']: Unsupported osfamily: ${::osfamily}")
+        }
     }
-    'Debian', 'Suse': {
-      $cert_path = '/etc/ssl/certs'
-      $key_path  = '/etc/ssl/private'
-      $service   = 'apache2'
-      $group     = 'root'
-    }
-    'FreeBSD': {
-      $cert_path = '/usr/local/etc/apache24'
-      $key_path  = '/usr/local/etc/apache24'
-      $service   = 'apache24'
-      $group     = 'wheel'
-    }
-    'Gentoo': {
-      $cert_path = '/etc/ssl/apache2'
-      $key_path  = '/etc/ssl/apache2'
-      $service   = 'apache2'
-      $group     = 'wheel'
-    }
-    default: {
-      fail("Class['certs::params']: Unsupported osfamily: ${::osfamily}")
-    }
-  }
-  $cert_ext      = '.crt'
-  $key_ext       = '.key'
-  $chain_name    = undef
-  $chain_ext     = $cert_ext
-  $chain_path    = $cert_path
-  $ca_name       = undef
-  $ca_ext        = $cert_ext
-  $ca_path       = $cert_path
-  $owner         = 'root'
-  $cert_mode     = '0644'
-  $key_mode      = '0600'
-  $cert_dir_mode = '0755'
-  $key_dir_mode  = '0755'
+    $ca_name       = undef
+    $cert_dir_mode = '0755'
+    $cert_ext      = '.crt'
+    $cert_mode     = '0644'
+    $chain_name    = undef
+    $dhparam_file  = 'dh2048.pem'
+    $key_dir_mode  = '0755'
+    $key_ext       = '.key'
+    $key_mode      = '0600'
+    $owner         = 'root'
+
+    $ca_ext        = $cert_ext
+    $ca_path       = $cert_path
+    $chain_ext     = $cert_ext
+    $chain_path    = $cert_path
 }

--- a/manifests/site.pp
+++ b/manifests/site.pp
@@ -7,6 +7,164 @@
 # other service requiring SSL certificates. It can also be used
 # independent of any Puppet-defined service.
 #
+# === Parameters
+#
+# [ca_cert]
+# Boolean for whether to look for a CA certificate file.
+# Optional value. Default: false.
+#
+# [ca_content]
+# A string representing the contents of the CA file.
+# Optional value. Default: undef.
+#
+# [ca_ext]
+# The extension of the CA certificate file.
+# Optional value. Default: crt.
+#
+# [ca_name]
+# The name of the CA certificate file.
+# Optional value. Default: undef.
+#
+# [ca_path]
+# Location where the CA certificate file will be stored on the managed node.
+# Optional value. Default: [cert_path].
+#
+# [ca_source_path]
+# The location of the CA certificate file. Typically references a module's files.
+# e.g. 'puppet:///ca_certs' will search for the mount point defined in the
+# fileserver.conf on the Puppet Server for the specified files.
+# Optional value. Default: [source_path].
+#
+# [cert_chain]
+# Boolean for whether to look for a certificate chain file.
+# Optional value. Default: false.
+#
+# [cert_content]
+# A string representing the contents of the certificate file.  This can only be
+# provided if $source_path is undefined or an error will occur.
+# Optional value. Default: undef.
+#
+# [cert_dir_mode]
+# Permissions of the certificate directory.
+# Optional value. Default: '0755'.
+#
+# [cert_ext]
+# The extension of the certificate file.
+# Optional value. Default: '.crt'.
+#
+# [cert_mode]
+# Permissions of the certificate files.
+# Optional value. Default: '0644'.
+#
+# [cert_path]
+# Location where the certificate files will be stored on the managed node.
+# Optional value. Defaults:
+#   - '/etc/pki/tls/certs' on RedHat-based systems
+#   - '/etc/ssl/certs' on Debian-based and Suse-based systems
+#   - '/usr/local/etc/apache24' on FreeBSD-based systems
+#   - '/etc/ssl/apache2' on Gentoo-based systems
+#
+# [chain_content]
+# A string representing the contents of the chain file.
+# Optional value. Default: undef.
+#
+# [chain_ext]
+# The extension of the certificate chain file.
+# Optional value. Default: crt.
+#
+# [chain_name]
+# The name of the certificate chain file.
+# Optional value. Default: undef.
+#
+# [chain_path]
+# Location where the certificate chain file will be stored on the managed node.
+# Optional value. Default: [cert_path].
+#
+# [chain_source_path]
+# The location of the certificate chain file. Typically references a module's files.
+# e.g. 'puppet:///chain_certs' will search for the mount point defined in the
+# fileserver.conf on the Puppet Server for the specified files.
+# Optional value. Default: [source_path].
+#
+# [dhparam]
+# A boolean value to determine whether a dhparam file should be placed on the
+# system along with the other certificate files.  The dhparam file will need to
+# exist on the source side just as with the other certificate files in order
+# for the file to be delivered.
+# Optional value. Default: false
+#
+# [dhparam_content]
+# A string representing the contents of the dhparam file.  This option will
+# take precedence over dhparam_file if it exists on the source side.
+# Optional value. Default: undef.
+#
+# [dhparam_file]
+# The name of the dhparam file.
+# Optional value. Default: 'dh2048.pem'.
+#
+# [ensure]
+# Ensure for the site resources.  If 'present', files will be put in place.  If
+# 'absent', files will be removed.
+# Optional value. Default: 'present'
+#
+# [group]
+# Name of the group owner of the certificates.
+# Optional value. Defaults:
+#   - 'root' for Redhat-based, Debian-based, and Suse-based systems
+#   - 'wheel' for FreeBSD and Gentoo-based systems
+#
+# [key_content]
+# A string representing the contents of the key file.  This can only be
+# provided if $source_path is undefined or an error will occur.
+# Optional value. Default: undef.
+#
+# [key_dir_mode]
+# Permissions of the private keys directory.
+# Optional value. Default: '0755'.
+#
+# [key_ext]
+# The extension of the private key file.
+# Optional value. Default: '.key'.
+#
+# [key_mode]
+# Permissions of the private keys.
+# Optional value. Default: '0600'.
+#
+# [key_path]
+# Location where the private keys will be stored on the managed node.
+# Optional value. Defaults:
+#   - '/etc/pki/tls/private' on RedHat-based systems
+#   - '/etc/ssl/private' on Debian-based and Suse-based systems
+#   - '/usr/local/etc/apache24' on FreeBSD-based systems
+#   - '/etc/ssl/apache2' on Gentoo-based systems
+#
+# [merge_chain]
+# Option to merge the CA and chain files into the actual certificate file,
+# which is required by some software.
+# Optional value. Default: false.
+#
+# [merge_key]
+# Option to merge the private into the actual certificate file, which is
+# required by some software.
+# Optional value. Default: false.
+#
+# [owner]
+# Name of the owner of the certificates.
+# Optional value. Default: 'root'.
+#
+# [service]
+# Name of the server service to notify when certificates are updated.
+# Setting to `undef` will disable service notifications.
+# Optional value. Defaults:
+#   - 'httpd' for RedHat-based systems
+#   - 'apache2' for Debian-based, Suse-based, and Gentoo-based systems
+#   - 'apache24' for FreeBSD-based systems
+#
+# [source_path]
+# The location of the certificate files. Typically references a module's files.
+# e.g. 'puppet:///site_certs' will search for the mount point defined in the
+# fileserver.conf on the Puppet Server for the specified files.
+#
 # === Examples
 #
 #  Without Hiera:
@@ -14,10 +172,10 @@
 #    include certs
 #    $cname = www.example.com
 #    certs::site { $cname:
-#      source_path    => 'puppet:///site_certificates',
-#      ca_cert        => true,
-#      ca_name        => 'caname',
-#      ca_source_path => 'puppet:///ca_certs',
+#        source_path    => 'puppet:///site_certificates',
+#        ca_cert        => true,
+#        ca_name        => 'caname',
+#        ca_source_path => 'puppet:///ca_certs',
 #    }
 #
 #  With Hiera:
@@ -25,13 +183,13 @@
 #    server.yaml
 #    ---
 #    classes:
-#      - certs
+#        - certs
 #    certs::sites:
-#      'www.example.com':
-#        source_path: 'puppet:///site_certificates'
-#        ca_cert: true
-#        ca_name: 'caname'
-#        ca_source_path: 'puppet:///ca_certs'
+#        'www.example.com':
+#            source_path: 'puppet:///site_certificates'
+#            ca_cert: true
+#            ca_name: 'caname'
+#            ca_source_path: 'puppet:///ca_certs'
 #
 #  Resource Chaining with Apache Module
 #
@@ -49,304 +207,326 @@
 # Copyright 2016
 #
 define certs::site(
-  $source_path       = undef,
-  $cert_content      = undef,
-  $key_content       = undef,
-  $ensure            = 'present',
-  $cert_ext          = undef,
-  $cert_path         = undef,
-  $key_ext           = undef,
-  $key_path          = undef,
-  $cert_chain        = false,
-  $chain_name        = undef,
-  $chain_ext         = undef,
-  $chain_path        = undef,
-  $chain_source_path = $source_path,
-  $chain_content     = undef,
-  $ca_cert           = false,
-  $ca_name           = undef,
-  $ca_ext            = undef,
-  $ca_path           = undef,
-  $ca_source_path    = $source_path,
-  $ca_content        = undef,
-  $service           = undef,
-  $owner             = undef,
-  $group             = undef,
-  $cert_mode         = undef,
-  $key_mode          = undef,
-  $cert_dir_mode     = undef,
-  $key_dir_mode      = undef,
-  $merge_chain       = false,
-  $merge_key         = false,
+    $ca_cert           = false,
+    $ca_content        = undef,
+    $ca_ext            = undef,
+    $ca_name           = undef,
+    $ca_path           = undef,
+    $ca_source_path    = undef,
+    $cert_chain        = false,
+    $cert_content      = undef,
+    $cert_dir_mode     = undef,
+    $cert_ext          = undef,
+    $cert_mode         = undef,
+    $cert_path         = undef,
+    $chain_content     = undef,
+    $chain_ext         = undef,
+    $chain_name        = undef,
+    $chain_path        = undef,
+    $chain_source_path = undef,
+    $dhparam           = 'absent',
+    $dhparam_content   = undef,
+    $dhparam_file      = undef,
+    $ensure            = 'present',
+    $group             = undef,
+    $key_content       = undef,
+    $key_dir_mode      = undef,
+    $key_ext           = undef,
+    $key_mode          = undef,
+    $key_path          = undef,
+    $owner             = undef,
+    $merge_chain       = false,
+    $merge_key         = false,
+    $service           = undef,
+    $source_path       = undef,
 ) {
 
   # The base class must be included first because it is used by parameter defaults
-  if ! defined(Class['certs']) {
-    fail('You must include the certs base class before using any certs defined resources')
-  }
-
-  if ($name == undef) {
-    fail('You must provide a name value for the site to certs::site.')
-  }
-  if ($source_path == undef and ($cert_content == undef or $key_content == undef)) {
-    fail('You must provide a source_path or cert_content/key_content combination for the SSL files to certs::site.')
-  }
-
-  if ($source_path and ($cert_content or $key_content)) {
-    fail('You can only provide $source_path or $cert_content/$key_content, not both.')
-  }
-
-  if !$source_path {
-    if !($cert_content and $key_content) {
-      fail('If source_path is not set, $cert_content and $key_content must both be set.')
+    if ! defined(Class['certs']) {
+        fail('You must include the certs base class before using any certs defined resources')
     }
-  }
 
-  validate_re($ensure, '^(present|absent)$')
-
-  $_cert_ext      = pick_default($cert_ext, $::certs::_cert_ext)
-  $_cert_path     = pick_default($cert_path, $::certs::_cert_path)
-  $_key_ext       = pick_default($key_ext, $::certs::_key_ext)
-  $_key_path      = pick_default($key_path, $::certs::_key_path)
-  $_chain_ext     = pick_default($chain_ext, $::certs::_chain_ext)
-  $_chain_path    = pick_default($chain_path, $::certs::_chain_path)
-  $_ca_ext        = pick_default($ca_ext, $::certs::_ca_ext)
-  $_ca_path       = pick_default($ca_path, $::certs::_ca_path)
-  $_service       = pick_default($service, $::certs::_service)
-  $_owner         = pick_default($owner, $::certs::_owner)
-  $_group         = pick_default($group, $::certs::_group)
-  $_cert_mode     = pick_default($cert_mode, $::certs::_cert_mode)
-  $_key_mode      = pick_default($key_mode, $::certs::_key_mode)
-  $_cert_dir_mode = pick_default($cert_dir_mode, $::certs::_cert_dir_mode)
-  $_key_dir_mode  = pick_default($key_dir_mode, $::certs::_key_dir_mode)
-
-  validate_string($_cert_ext)
-  validate_absolute_path($_cert_path)
-  validate_string($_key_ext)
-  validate_absolute_path($_key_path)
-  validate_string($_chain_ext)
-  validate_absolute_path($_chain_path)
-  validate_string($_ca_ext)
-  validate_absolute_path($_ca_path)
-
-  if $service != undef {
-    validate_string($service)
-  }
-
-  validate_string($_owner)
-  validate_string($_group)
-  validate_string($_cert_mode)
-  validate_numeric($_cert_mode)
-  validate_string($_key_mode)
-  validate_numeric($_key_mode)
-  validate_string($_cert_dir_mode)
-  validate_numeric($_cert_dir_mode)
-  validate_string($_key_dir_mode)
-  validate_numeric($_key_dir_mode)
-
-  validate_bool($cert_chain)
-  if $cert_chain {
-    if ($chain_name == undef) {
-      fail('You must provide a chain_name value for the cert chain to certs::site.')
+    if ($name == undef) {
+        fail('You must provide a name value for the site to certs::site.')
     }
-    $chain = "${chain_name}${_chain_ext}"
+    if ($source_path == undef and ($cert_content == undef or $key_content == undef)) {
+        fail('You must provide a source_path or cert_content/key_content combination for the SSL files to certs::site.')
+    }
 
-    if $chain_content == undef {
-      if ($chain_source_path == undef) {
-        fail('You must provide a chain_source_path for the SSL files to certs::site.')
-      }
+    if ($source_path and ($cert_content or $key_content)) {
+        fail('You can only provide $source_path or $cert_content/$key_content, not both.')
+    }
 
-      $chain_source = "${chain_source_path}/${chain}"
+    if !$source_path {
+        if !($cert_content and $key_content) {
+            fail('If source_path is not set, $cert_content and $key_content must both be set.')
+        }
+    }
+
+    $_ca_ext        = pick_default($ca_ext, $::certs::_ca_ext)
+    $_ca_path       = pick_default($ca_path, $::certs::_ca_path)
+    $_cert_dir_mode = pick_default($cert_dir_mode, $::certs::_cert_dir_mode)
+    $_cert_ext      = pick_default($cert_ext, $::certs::_cert_ext)
+    $_cert_mode     = pick_default($cert_mode, $::certs::_cert_mode)
+    $_cert_path     = pick_default($cert_path, $::certs::_cert_path)
+    $_chain_ext     = pick_default($chain_ext, $::certs::_chain_ext)
+    $_chain_path    = pick_default($chain_path, $::certs::_chain_path)
+    $_dhparam_file  = pick_default($dhparam_file, $::certs::_dhparam_file)
+    $_group         = pick_default($group, $::certs::_group)
+    $_key_dir_mode  = pick_default($key_dir_mode, $::certs::_key_dir_mode)
+    $_key_ext       = pick_default($key_ext, $::certs::_key_ext)
+    $_key_mode      = pick_default($key_mode, $::certs::_key_mode)
+    $_key_path      = pick_default($key_path, $::certs::_key_path)
+    $_owner         = pick_default($owner, $::certs::_owner)
+    $_service       = pick_default($service, $::certs::_service)
+
+    if $ca_source_path {
+        $_ca_source_path = $ca_source_path
     } else {
-      $chain_source = undef
+        $_ca_source_path = $source_path
     }
-  }
 
-  validate_bool($ca_cert)
-  if $ca_cert {
-    if ($ca_name == undef) {
-      fail('You must provide a ca_name value for the CA cert to certs::site.')
-    }
-    $ca = "${ca_name}${_ca_ext}"
-
-    if $ca_content == undef {
-      if ($ca_source_path == undef) {
-        fail('You must provide a ca_source_path for the SSL files to certs::site.')
-      }
-
-      $ca_source = "${ca_source_path}/${ca}"
+    if $chain_source_path {
+        $_chain_source_path = $chain_source_path
     } else {
-      $ca_source = undef
+        $_chain_source_path = $source_path
     }
-  }
 
-  validate_bool($merge_chain)
+    validate_bool($ca_cert)
+    validate_string($_ca_ext)
+    validate_absolute_path($_ca_path)
+    validate_bool($cert_chain)
+    validate_string($_cert_dir_mode)
+    validate_numeric($_cert_dir_mode)
+    validate_string($_cert_ext)
+    validate_string($_cert_mode)
+    validate_numeric($_cert_mode)
+    validate_absolute_path($_cert_path)
+    validate_string($_chain_ext)
+    validate_absolute_path($_chain_path)
+    validate_re($ensure, '^(present|absent)$')
+    validate_string($_group)
+    validate_string($_key_dir_mode)
+    validate_numeric($_key_dir_mode)
+    validate_string($_key_ext)
+    validate_string($_key_mode)
+    validate_numeric($_key_mode)
+    validate_absolute_path($_key_path)
+    validate_bool($merge_chain)
+    validate_string($_owner)
 
-  $cert = "${name}${_cert_ext}"
-  $key  = "${name}${_key_ext}"
+    if $service != undef {
+        validate_string($service)
+    }
 
-  if $service != undef {
-    if defined(Service[$service]) {
-      $service_notify = Service[$service]
+    if $cert_chain {
+        if ($chain_name == undef) {
+            fail('You must provide a chain_name value for the cert chain to certs::site.')
+        }
+        $chain = "${chain_name}${_chain_ext}"
+
+        if $chain_content == undef {
+            if ($_chain_source_path == undef) {
+                fail('You must provide a chain_source_path for the SSL files to certs::site.')
+            }
+
+            $chain_source = "${_chain_source_path}/${chain}"
+        } else {
+            $chain_source = undef
+        }
+    }
+
+    if $ca_cert {
+        if ($ca_name == undef) {
+            fail('You must provide a ca_name value for the CA cert to certs::site.')
+        }
+        $ca = "${ca_name}${_ca_ext}"
+
+        if $ca_content == undef {
+            if ($_ca_source_path == undef) {
+                fail('You must provide a ca_source_path for the SSL files to certs::site.')
+            }
+
+            $ca_source = "${_ca_source_path}/${ca}"
+        } else {
+            $ca_source = undef
+        }
+    }
+
+    $cert = "${name}${_cert_ext}"
+    $key  = "${name}${_key_ext}"
+
+    if $service != undef {
+        if defined(Service[$service]) {
+            $service_notify = Service[$service]
+        } else {
+            $service_notify = undef
+        }
     } else {
-      $service_notify = undef
+        $service_notify = undef
     }
-  } else {
-    $service_notify = undef
-  }
 
-  if !defined(File[$_cert_path]) {
-    file { $_cert_path:
-      ensure => 'directory',
-      backup => false,
-      owner  => $_owner,
-      group  => $_group,
-      mode   => $_cert_dir_mode,
+    if !defined(File[$_cert_path]) {
+        file { $_cert_path:
+            ensure => 'directory',
+            backup => false,
+            owner  => $_owner,
+            group  => $_group,
+            mode   => $_cert_dir_mode,
+        }
     }
-  }
 
-  if !defined(File[$_chain_path]) {
-    file { $_chain_path:
-      ensure => 'directory',
-      backup => false,
-      owner  => $_owner,
-      group  => $_group,
-      mode   => $_cert_dir_mode,
+    if !defined(File[$_chain_path]) {
+        file { $_chain_path:
+            ensure => 'directory',
+            backup => false,
+            owner  => $_owner,
+            group  => $_group,
+            mode   => $_cert_dir_mode,
+        }
     }
-  }
 
-  if !defined(File[$_ca_path]) {
-    file { $_ca_path:
-      ensure => 'directory',
-      backup => false,
-      owner  => $_owner,
-      group  => $_group,
-      mode   => $_cert_dir_mode,
+    if !defined(File[$_ca_path]) {
+        file { $_ca_path:
+            ensure => 'directory',
+            backup => false,
+            owner  => $_owner,
+            group  => $_group,
+            mode   => $_cert_dir_mode,
+        }
     }
-  }
 
-  if !defined(File[$_key_path]) {
-    file { $_key_path:
-      ensure => 'directory',
-      backup => false,
-      owner  => $_owner,
-      group  => $_group,
-      mode   => $_key_dir_mode,
+    if !defined(File[$_key_path]) {
+        file { $_key_path:
+            ensure => 'directory',
+            backup => false,
+            owner  => $_owner,
+            group  => $_group,
+            mode   => $_key_dir_mode,
+        }
     }
-  }
 
-  if $source_path == undef {
-    $cert_source = undef
-    $key_source = undef
-  } else {
-    $cert_source = "${source_path}/${cert}"
-    $key_source = "${source_path}/${key}"
-  }
+    if $source_path == undef {
+        $cert_source = undef
+        $key_source = undef
+    } else {
+        $cert_source = "${source_path}/${cert}"
+        $key_source = "${source_path}/${key}"
+    }
 
-  if $ensure == 'present' {
     if $merge_chain or $merge_key {
-      concat { "${name}_cert_merged":
-        ensure         => 'present',
-        ensure_newline => true,
-        backup         => false,
-        path           => "${_cert_path}/${cert}",
-        owner          => $_owner,
-        group          => $_group,
-        mode           => $_cert_mode,
-        require        => File[$_cert_path],
-        notify         => $service_notify,
-      }
+        concat { "${name}_cert_merged":
+            ensure         => $ensure,
+            ensure_newline => true,
+            backup         => false,
+            path           => "${_cert_path}/${cert}",
+            owner          => $_owner,
+            group          => $_group,
+            mode           => $_cert_mode,
+            require        => File[$_cert_path],
+            notify         => $service_notify,
+        }
 
-      concat::fragment { "${cert}_certificate":
-        target  => "${name}_cert_merged",
-        source  => $cert_source,
-        content => $cert_content,
-        order   => '01'
-      }
-
-      if $merge_key {
-          concat::fragment { "${cert}_key":
+        concat::fragment { "${cert}_certificate":
             target  => "${name}_cert_merged",
-            source  => $key_source,
-            content => $key_content,
-            order   => '02'
-          }
-      }
+            source  => $cert_source,
+            content => $cert_content,
+            order   => '01'
+        }
 
-      if $merge_chain {
-          if $cert_chain {
-            concat::fragment { "${cert}_chain":
-              target  => "${name}_cert_merged",
-              source  => $chain_source,
-              content => $chain_content,
-              order   => '50'
+        if $merge_key {
+            concat::fragment { "${cert}_key":
+                target  => "${name}_cert_merged",
+                source  => $key_source,
+                content => $key_content,
+                order   => '02'
             }
-          }
-          if $ca_cert {
-            concat::fragment { "${cert}_ca":
-              target  => "${name}_cert_merged",
-              source  => $ca_source,
-              content => $ca_content,
-              order   => '90'
+        }
+
+        if $merge_chain {
+            if $cert_chain {
+                concat::fragment { "${cert}_chain":
+                    target  => "${name}_cert_merged",
+                    source  => $chain_source,
+                    content => $chain_content,
+                    order   => '50'
+                }
             }
-          }
-      }
+            if $ca_cert {
+                concat::fragment { "${cert}_ca":
+                    target  => "${name}_cert_merged",
+                    source  => $ca_source,
+                    content => $ca_content,
+                    order   => '90'
+                }
+            }
+        }
     } else {
-      file { "${_cert_path}/${cert}":
-        ensure  => file,
-        source  => $cert_source,
-        content => $cert_content,
+        file { "${_cert_path}/${cert}":
+            ensure  => $ensure,
+            source  => $cert_source,
+            content => $cert_content,
+            owner   => $_owner,
+            group   => $_group,
+            mode    => $_cert_mode,
+            require => File[$_cert_path],
+            notify  => $service_notify,
+        }
+    }
+
+    file { "${_key_path}/${key}":
+        ensure  => $ensure,
+        source  => $key_source,
+        content => $key_content,
         owner   => $_owner,
         group   => $_group,
-        mode    => $_cert_mode,
-        require => File[$_cert_path],
+        mode    => $_key_mode,
+        require => File[$_key_path],
         notify  => $service_notify,
-      }
     }
 
-    file { "${_key_path}/${key}":
-      ensure  => file,
-      source  => $key_source,
-      content => $key_content,
-      owner   => $_owner,
-      group   => $_group,
-      mode    => $_key_mode,
-      require => File[$_key_path],
-      notify  => $service_notify,
-    }
-  } else {
-    file { "${_cert_path}/${cert}":
-      ensure => $ensure,
+    if ($cert_chain and !defined(File["${_chain_path}/${chain}"])) {
+        file { "${_chain_path}/${chain}":
+            ensure  => 'file',
+            source  => $chain_source,
+            content => $chain_content,
+            owner   => $_owner,
+            group   => $_group,
+            mode    => $_cert_mode,
+            require => File[$_chain_path],
+            notify  => $service_notify,
+        }
     }
 
-    file { "${_key_path}/${key}":
-      ensure => $ensure,
+    if ($ca_cert and !defined(File["${_ca_path}/${ca}"])) {
+        file { "${_ca_path}/${ca}":
+            ensure  => 'file',
+            source  => $ca_source,
+            content => $ca_content,
+            owner   => $_owner,
+            group   => $_group,
+            mode    => $_cert_mode,
+            require => File[$_ca_path],
+            notify  => $service_notify,
+        }
     }
-  }
 
-  if ($cert_chain and !defined(File["${_chain_path}/${chain}"])) {
-    file { "${_chain_path}/${chain}":
-      ensure  => file,
-      source  => $chain_source,
-      content => $chain_content,
-      owner   => $_owner,
-      group   => $_group,
-      mode    => $_cert_mode,
-      require => File[$_chain_path],
-      notify  => $service_notify,
-    }
-  }
+    if ($dhparam and !defined(File["${_cert_path}/${name}_${_dhparam_file}"])) {
+        if $dhparam_content {
+            $dhparam_source = undef
+        } else {
+            $dhparam_source = "${source_path}/${_dhparam_file}"
+        }
 
-  if ($ca_cert and !defined(File["${_ca_path}/${ca}"])) {
-    file { "${_ca_path}/${ca}":
-      ensure  => file,
-      source  => $ca_source,
-      content => $ca_content,
-      owner   => $_owner,
-      group   => $_group,
-      mode    => $_cert_mode,
-      require => File[$_ca_path],
-      notify  => $service_notify,
+        file { "${_cert_path}/${name}_${_dhparam_file}":
+            ensure  => $ensure,
+            source  => $dhparam_source,
+            content => $dhparam_content,
+            owner   => $_owner,
+            group   => $_group,
+            mode    => $_cert_mode,
+            require => File[$_cert_path],
+            notify  => $service_notify,
+        }
     }
-  }
 }

--- a/metadata.json
+++ b/metadata.json
@@ -1,10 +1,7 @@
 {
   "name": "broadinstitute-certs",
-  "version": "1.1.0",
-  "author": [
-    "Riccardo Calixte <rcalixte@broadinstitute.org>",
-    "Andrew Teixeira <teixeira@broadinstitute.org"
-  ],
+  "version": "1.2.0",
+  "author": "Riccardo Calixte <rcalixte@broadinstitute.org>",
   "description": "Module for SSL certificate configuration",
   "summary": "Configures and manages SSL certificate deployments, restarting services as configured.",
   "license": "Apache-2.0",

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -2,65 +2,62 @@ require 'spec_helper'
 
 describe 'certs', :type => :class do
 
-  [ 'Debian', 'FreeBSD', 'Gentoo', 'RedHat' ].each do |osfamily|
+    [ 'Debian', 'FreeBSD', 'Gentoo', 'RedHat' ].each do |osfamily|
 
-    context "on #{osfamily}" do
+        context "on #{osfamily}" do
 
-      if osfamily == 'Debian'
-        let(:facts) { {
-          :osfamily               => 'Debian',
-          :operatingsystem        => 'Debian',
-          :lsbdistid              => 'Debian',
-          :lsbdistcodename        => 'wheezy',
-          :operatingsystemrelease => '7.3',
-          :operatingsystemmajrelease => '7',
-        } }
+            if osfamily == 'Debian'
+                let(:facts) {{
+                    :osfamily               => 'Debian',
+                    :operatingsystem        => 'Debian',
+                    :lsbdistid              => 'Debian',
+                    :lsbdistcodename        => 'wheezy',
+                    :operatingsystemrelease => '7.3',
+                    :operatingsystemmajrelease => '7',
+                }}
 
-        context 'with defaults for all parameters' do
-          it { is_expected.to contain_class('certs') }
+                context 'with defaults for all parameters' do
+                    it { is_expected.to contain_class('certs') }
+                end
+            end
+
+            if osfamily == 'FreeBSD'
+                let(:facts) {{
+                    :osfamily => osfamily,
+                    :operatingsystem => 'FreeBSD',
+                    :operatingsystemrelease => '10.0-RELEASE-p18',
+                    :operatingsystemmajrelease => '10',
+                }}
+
+                context 'with defaults for all parameters' do
+                    it { is_expected.to contain_class('certs') }
+                end
+            end
+
+            if osfamily == 'Gentoo'
+                let(:facts) {{
+                    :osfamily => osfamily,
+                    :operatingsystem => 'Gentoo',
+                    :operatingsystemrelease => '3.16.1-gentoo',
+                }}
+
+                context 'with defaults for all parameters' do
+                    it { is_expected.to contain_class('certs') }
+                end
+            end
+
+            if osfamily == 'RedHat'
+                let(:facts) {{
+                    :osfamily => osfamily,
+                    :operatingsystem => 'RedHat',
+                    :operatingsystemrelease => '7.2',
+                    :operatingsystemmajrelease => '7',
+                }}
+
+                context 'with defaults for all parameters' do
+                    it { is_expected.to contain_class('certs') }
+                end
+            end
         end
-      end
-
-      if osfamily == 'FreeBSD'
-        let(:facts) { {
-          :osfamily => osfamily,
-          :operatingsystem => 'FreeBSD',
-          :operatingsystemrelease => '10.0-RELEASE-p18',
-          :operatingsystemmajrelease => '10',
-        } }
-
-        context 'with defaults for all parameters' do
-          it { is_expected.to contain_class('certs') }
-        end
-
-      end
-
-      if osfamily == 'Gentoo'
-        let(:facts) { {
-          :osfamily => osfamily,
-          :operatingsystem => 'Gentoo',
-          :operatingsystemrelease => '3.16.1-gentoo',
-        } }
-
-        context 'with defaults for all parameters' do
-          it { is_expected.to contain_class('certs') }
-        end
-
-      end
-
-      if osfamily == 'RedHat'
-        let(:facts) { {
-          :osfamily => osfamily,
-          :operatingsystem => 'RedHat',
-          :operatingsystemrelease => '7.2',
-          :operatingsystemmajrelease => '7',
-        } }
-
-        context 'with defaults for all parameters' do
-          it { is_expected.to contain_class('certs') }
-        end
-      end
-
     end
-  end
 end

--- a/spec/defines/site_spec.rb
+++ b/spec/defines/site_spec.rb
@@ -1,531 +1,766 @@
 require 'spec_helper'
 
 describe 'certs::site', :type => :define do
-  let (:title) { 'base.example.org' }
+    let (:title) { 'base.example.org' }
 
-  [ 'Debian', 'FreeBSD', 'Gentoo', 'RedHat', 'Suse' ].each do |osfamily|
+    [ 'Debian', 'FreeBSD', 'Gentoo', 'RedHat', 'Suse' ].each do |osfamily|
 
-    context "on #{osfamily}" do
-      # This define requires the certs class, so make sure it's defined
-      let :pre_condition do
-        'class { "certs": }'
-      end
+        context "on #{osfamily}" do
+            # This define requires the certs class, so make sure it's defined
+            let :pre_condition do
+                'class { "certs": }'
+            end
 
-      if osfamily == 'Debian'
-        let(:facts) { {
-          :osfamily                  => 'Debian',
-          :operatingsystem           => 'Debian',
-          :lsbdistid                 => 'Debian',
-          :lsbdistcodename           => 'wheezy',
-          :operatingsystemrelease    => '7.3',
-          :operatingsystemmajrelease => '7',
-        } }
+            if osfamily == 'Debian'
+                let(:facts) { {
+                    :osfamily                  => 'Debian',
+                    :operatingsystem           => 'Debian',
+                    :lsbdistid                 => 'Debian',
+                    :lsbdistcodename           => 'wheezy',
+                    :operatingsystemrelease    => '7.3',
+                    :operatingsystemmajrelease => '7',
+                } }
 
-        context 'with only cert and key content set' do
-          let(:params) {
-            {
-              :cert_content => 'cert1111',
-              :key_content  => 'key1111',
-              :service      => :undef,
-            }
-          }
+                context 'with only cert and key content set' do
+                    let(:params) {{
+                        :cert_content => 'cert1111',
+                        :key_content  => 'key1111',
+                        :service      => :undef,
+                    }}
 
-          it { is_expected.to contain_file('/etc/ssl/certs').with_ensure('directory') }
-          it { is_expected.to contain_file('/etc/ssl/private').with_ensure('directory') }
-          it { is_expected.to contain_file('/etc/ssl/certs/base.example.org.crt').with_group('root') }
-          it { is_expected.to contain_file('/etc/ssl/private/base.example.org.key').with_group('root') }
+                    it { is_expected.to contain_file('/etc/ssl/certs').
+                        with_ensure('directory')
+                    }
+                    it { is_expected.to contain_file('/etc/ssl/private').
+                        with_ensure('directory')
+                    }
+                    it { is_expected.to contain_file('/etc/ssl/certs/base.example.org.crt').
+                        with_group('root')
+                    }
+                    it { is_expected.to contain_file('/etc/ssl/private/base.example.org.key').
+                        with_group('root')
+                    }
+                end
+            end
+
+            if osfamily == 'FreeBSD'
+                let(:facts) { {
+                  :osfamily                  => osfamily,
+                  :operatingsystem           => 'FreeBSD',
+                  :operatingsystemrelease    => '10.0-RELEASE-p18',
+                  :operatingsystemmajrelease => '10',
+                } }
+
+                context 'with only cert and key content set' do
+                    let(:params) {{
+                        :cert_content => 'cert1111',
+                        :key_content  => 'key1111',
+                        :service      => :undef,
+                    }}
+
+                    it { is_expected.to contain_file('/usr/local/etc/apache24').
+                        with_ensure('directory')
+                    }
+                    it { is_expected.to contain_file('/usr/local/etc/apache24').
+                        with_group('wheel')
+                    }
+                    it { is_expected.to contain_file('/usr/local/etc/apache24/base.example.org.crt').
+                        with_group('wheel')
+                    }
+                    it { is_expected.to contain_file('/usr/local/etc/apache24/base.example.org.key').
+                        with_group('wheel')
+                    }
+                end
+            end
+
+            if osfamily == 'Gentoo'
+                let(:facts) {{
+                    :osfamily               => osfamily,
+                    :operatingsystem        => 'Gentoo',
+                    :operatingsystemrelease => '3.16.1-gentoo',
+                }}
+
+                context 'with only cert and key content set' do
+                    let(:params) {{
+                        :cert_content => 'cert1111',
+                        :key_content  => 'key1111',
+                        :service      => :undef,
+                    }}
+
+                    it { is_expected.to contain_file('/etc/ssl/apache2').
+                        with_ensure('directory')
+                    }
+                    it { is_expected.to contain_file('/etc/ssl/apache2').
+                        with_group('wheel')
+                    }
+                    it { is_expected.to contain_file('/etc/ssl/apache2/base.example.org.crt').
+                        with_group('wheel')
+                    }
+                    it { is_expected.to contain_file('/etc/ssl/apache2/base.example.org.key').
+                        with_group('wheel')
+                    }
+                end
+            end
+
+            if osfamily == 'RedHat'
+                let(:facts) {{
+                    :osfamily                  => osfamily,
+                    :operatingsystem           => 'RedHat',
+                    :operatingsystemrelease    => '7.2',
+                    :operatingsystemmajrelease => '7',
+                }}
+
+                context 'with only cert and key content set' do
+                    let(:params) {{
+                        :cert_content => 'cert1111',
+                        :key_content  => 'key1111',
+                        :service      => :undef,
+                    }}
+
+                    it { is_expected.to contain_file('/etc/pki/tls/certs').
+                        with_ensure('directory')
+                    }
+                    it { is_expected.to contain_file('/etc/pki/tls/private').
+                        with_ensure('directory')
+                    }
+                    it { is_expected.to contain_file('/etc/pki/tls/certs/base.example.org.crt').
+                        with_group('root')
+                    }
+                    it { is_expected.to contain_file('/etc/pki/tls/private/base.example.org.key').
+                        with_group('root')
+                    }
+                end
+            end
+        end
+    end
+
+    context "on Debian-like setup for the remaining tests" do
+
+        let(:facts) {{
+            :osfamily                  => 'Debian',
+            :operatingsystem           => 'Debian',
+            :lsbdistid                 => 'Debian',
+            :lsbdistcodename           => 'wheezy',
+            :operatingsystemrelease    => '7.3',
+            :operatingsystemmajrelease => '7',
+        }}
+
+        # This define requires the certs class, so make sure it's defined
+        let :pre_condition do
+            'class { "certs": }'
         end
 
-      end
-
-      if osfamily == 'FreeBSD'
-        let(:facts) { {
-          :osfamily                  => osfamily,
-          :operatingsystem           => 'FreeBSD',
-          :operatingsystemrelease    => '10.0-RELEASE-p18',
-          :operatingsystemmajrelease => '10',
-        } }
-
         context 'with only cert and key content set' do
-          let(:params) {
-            {
-              :cert_content => 'cert1111',
-              :key_content  => 'key1111',
-              :service      => :undef,
-            }
-          }
+            let(:params) {{
+                :cert_content => 'cert1111',
+                :key_content  => 'key1111',
+                :service      => :undef,
+            }}
 
-          it { is_expected.to contain_file('/usr/local/etc/apache24').with_ensure('directory') }
-          it { is_expected.to contain_file('/usr/local/etc/apache24').with_group('wheel') }
-          it { is_expected.to contain_file('/usr/local/etc/apache24/base.example.org.crt').with_group('wheel') }
-          it { is_expected.to contain_file('/usr/local/etc/apache24/base.example.org.key').with_group('wheel') }
+            it { is_expected.to contain_file('/etc/ssl/certs/base.example.org.crt').
+                with_content(/cert1111/)
+            }
+            it { is_expected.to contain_file('/etc/ssl/private/base.example.org.key').
+                with_content(/key1111/)
+            }
         end
 
-      end
+        context 'with only cert and key using source_path' do
+            let(:params) {{
+                :service      => :undef,
+                :source_path  => 'puppet:///site_certs/base.example.org',
+            }}
 
-      if osfamily == 'Gentoo'
-        let(:facts) { {
-          :osfamily               => osfamily,
-          :operatingsystem        => 'Gentoo',
-          :operatingsystemrelease => '3.16.1-gentoo',
-        } }
-
-        context 'with only cert and key content set' do
-          let(:params) {
-            {
-              :cert_content => 'cert1111',
-              :key_content  => 'key1111',
-              :service      => :undef,
+            it { is_expected.to contain_file('/etc/ssl/certs/base.example.org.crt').
+                with_source(/puppet:\/\/\/site_certs\/base.example.org\/base\.example\.org\.crt/)
             }
-          }
-
-          it { is_expected.to contain_file('/etc/ssl/apache2').with_ensure('directory') }
-          it { is_expected.to contain_file('/etc/ssl/apache2').with_group('wheel') }
-          it { is_expected.to contain_file('/etc/ssl/apache2/base.example.org.crt').with_group('wheel') }
-          it { is_expected.to contain_file('/etc/ssl/apache2/base.example.org.key').with_group('wheel') }
+            it { is_expected.to contain_file('/etc/ssl/private/base.example.org.key').
+                with_source(/puppet:\/\/\/site_certs\/base.example.org\/base\.example\.org\.key/)
+            }
         end
 
-      end
+        context 'with ensure => absent' do
+            let(:params) {{
+                :service     => :undef,
+                :ensure      => 'absent',
+                :source_path => 'puppet:///site_certs/base.example.org',
+            }}
 
-      if osfamily == 'RedHat'
-        let(:facts) { {
-          :osfamily                  => osfamily,
-          :operatingsystem           => 'RedHat',
-          :operatingsystemrelease    => '7.2',
-          :operatingsystemmajrelease => '7',
-        } }
-
-        context 'with only cert and key content set' do
-          let(:params) {
-            {
-              :cert_content => 'cert1111',
-              :key_content  => 'key1111',
-              :service      => :undef,
+            it { is_expected.to contain_file('/etc/ssl/certs/base.example.org.crt').
+                with_ensure('absent')
             }
-          }
-
-          it { is_expected.to contain_file('/etc/pki/tls/certs').with_ensure('directory') }
-          it { is_expected.to contain_file('/etc/pki/tls/private').with_ensure('directory') }
-          it { is_expected.to contain_file('/etc/pki/tls/certs/base.example.org.crt').with_group('root') }
-          it { is_expected.to contain_file('/etc/pki/tls/private/base.example.org.key').with_group('root') }
+            it { is_expected.to contain_file('/etc/ssl/private/base.example.org.key').
+                with_ensure('absent')
+            }
         end
 
-      end
+        context 'with ensure => absent and dhparam => true' do
+            let(:params) {{
+                :service     => :undef,
+                :ensure      => 'absent',
+                :dhparam     => true,
+                :source_path => 'puppet:///site_certs/base.example.org',
+            }}
+
+            it { is_expected.to contain_file('/etc/ssl/certs/base.example.org.crt').
+                with_ensure('absent')
+            }
+            it { is_expected.to contain_file('/etc/ssl/private/base.example.org.key').
+                with_ensure('absent')
+            }
+            it { is_expected.to contain_file('/etc/ssl/certs/base.example.org_dh2048.pem').
+                with_ensure('absent')
+            }
+        end
+
+        context 'with CA cert content' do
+            let(:params) {{
+                :cert_content => 'cert1111',
+                :key_content  => 'key1111',
+                :service      => :undef,
+                :ca_cert      => true,
+                :ca_name      => 'ca',
+                :ca_content   => 'ca2222',
+                :ensure       => 'present',
+            }}
+
+            it { is_expected.to contain_file('/etc/ssl/certs/base.example.org.crt').
+                with_content(/cert1111/)
+            }
+            it { is_expected.to contain_file('/etc/ssl/private/base.example.org.key').
+                with_content(/key1111/)
+            }
+            it { is_expected.to contain_file('/etc/ssl/certs/ca.crt').
+                with_content(/ca2222/)
+            }
+        end
+
+        context 'with CA cert and just source_path' do
+            let(:params) {{
+                :service        => :undef,
+                :ca_cert        => true,
+                :ca_name        => 'ca',
+                :ensure         => 'present',
+                :source_path    => 'puppet:///site_certs/base.example.org',
+            }}
+
+            it { is_expected.to contain_file('/etc/ssl/certs/base.example.org.crt').
+                with_source(/puppet:\/\/\/site_certs\/base.example.org\/base\.example\.org\.crt/)
+            }
+            it { is_expected.to contain_file('/etc/ssl/private/base.example.org.key').
+                with_source(/puppet:\/\/\/site_certs\/base.example.org\/base\.example\.org\.key/)
+            }
+            it { is_expected.to contain_file('/etc/ssl/certs/ca.crt').
+                with_source(/puppet:\/\/\/site_certs\/base.example.org\/ca\.crt/)
+            }
+        end
+
+        context 'with CA cert and ca_source_path' do
+            let(:params) {{
+                :service        => :undef,
+                :ca_cert        => true,
+                :ca_name        => 'ca',
+                :ensure         => 'present',
+                :source_path    => 'puppet:///site_certs/base.example.org',
+                :ca_source_path => 'puppet:///site_certs',
+            }}
+
+            it { is_expected.to contain_file('/etc/ssl/certs/base.example.org.crt').
+                with_source(/puppet:\/\/\/site_certs\/base.example.org\/base\.example\.org\.crt/)
+            }
+            it { is_expected.to contain_file('/etc/ssl/private/base.example.org.key').
+                with_source(/puppet:\/\/\/site_certs\/base.example.org\/base\.example\.org\.key/)
+            }
+            it { is_expected.to contain_file('/etc/ssl/certs/ca.crt').
+                with_source(/puppet:\/\/\/site_certs\/ca\.crt/)
+            }
+        end
+
+        context 'with chain cert content' do
+            let(:params) {{
+                :cert_content  => 'cert1111',
+                :key_content   => 'key1111',
+                :service       => :undef,
+                :cert_chain    => true,
+                :chain_name    => 'chain',
+                :chain_content => 'chain3333',
+                :ensure        => 'present'
+            }}
+
+            it { is_expected.to contain_file('/etc/ssl/certs/base.example.org.crt').
+                with_content(/cert1111/)
+            }
+            it { is_expected.to contain_file('/etc/ssl/private/base.example.org.key').
+                with_content(/key1111/)
+            }
+            it { is_expected.to contain_file('/etc/ssl/certs/chain.crt').
+                with_content(/chain3333/)
+            }
+        end
+
+        context 'with chain cert and just source_path' do
+            let(:params) {{
+                :service     => :undef,
+                :cert_chain  => true,
+                :chain_name  => 'chain',
+                :ensure      => 'present',
+                :source_path => 'puppet:///site_certs/base.example.org',
+            }}
+
+            it { is_expected.to contain_file('/etc/ssl/certs/base.example.org.crt').
+                with_source(/puppet:\/\/\/site_certs\/base.example.org\/base\.example\.org\.crt/)
+            }
+            it { is_expected.to contain_file('/etc/ssl/private/base.example.org.key').
+                with_source(/puppet:\/\/\/site_certs\/base.example.org\/base\.example\.org\.key/)
+            }
+            it { is_expected.to contain_file('/etc/ssl/certs/chain.crt').
+                with_source(/puppet:\/\/\/site_certs\/base.example.org\/chain\.crt/)
+            }
+        end
+
+        context 'with chain cert and chain_source_path' do
+            let(:params) {{
+                :service           => :undef,
+                :cert_chain        => true,
+                :chain_name        => 'chain',
+                :ensure            => 'present',
+                :source_path       => 'puppet:///site_certs/base.example.org',
+                :chain_source_path => 'puppet:///site_certs',
+            }}
+
+            it { is_expected.to contain_file('/etc/ssl/certs/base.example.org.crt').
+                with_source(/puppet:\/\/\/site_certs\/base.example.org\/base\.example\.org\.crt/)
+            }
+            it { is_expected.to contain_file('/etc/ssl/private/base.example.org.key').
+                with_source(/puppet:\/\/\/site_certs\/base.example.org\/base\.example\.org\.key/)
+            }
+            it { is_expected.to contain_file('/etc/ssl/certs/chain.crt').
+                with_source(/puppet:\/\/\/site_certs\/chain\.crt/)
+            }
+        end
+
+        context 'with merge_chain set to true with CA' do
+            let(:params) {{
+                :cert_content => 'cert1111',
+                :key_content  => 'key1111',
+                :service      => :undef,
+                :ensure       => 'present',
+                :ca_cert      => true,
+                :ca_name      => 'ca',
+                :ca_content   => 'ca2222',
+                :merge_chain  => true
+            }}
+
+            it { is_expected.to contain_concat('base.example.org_cert_merged') }
+            it { is_expected.to contain_concat__fragment('base.example.org.crt_certificate').
+                with_content(/cert1111/)
+            }
+            it { is_expected.to contain_concat__fragment('base.example.org.crt_ca').
+                with_content(/ca2222/)
+            }
+            it { is_expected.to contain_file('/etc/ssl/private/base.example.org.key').
+                with_content(/key1111/)
+            }
+            it { is_expected.to contain_file('/etc/ssl/certs/ca.crt').
+                with_content(/ca2222/)
+            }
+        end
+
+        context 'with merge_chain set to true with chain' do
+            let(:params) {{
+                :cert_content  => 'cert1111',
+                :key_content   => 'key1111',
+                :service       => :undef,
+                :ensure        => 'present',
+                :cert_chain    => true,
+                :chain_name    => 'chain',
+                :chain_content => 'chain3333',
+                :merge_chain   => true
+            }}
+
+            it { is_expected.to contain_concat('base.example.org_cert_merged') }
+            it { is_expected.to contain_concat__fragment('base.example.org.crt_certificate').
+                with_content(/cert1111/)
+            }
+            it { is_expected.to contain_concat__fragment('base.example.org.crt_chain').
+                with_content(/chain3333/)
+            }
+            it { is_expected.to contain_file('/etc/ssl/private/base.example.org.key').
+                with_content(/key1111/)
+            }
+            it { is_expected.to contain_file('/etc/ssl/certs/chain.crt').
+                with_content(/chain3333/)
+            }
+        end
+
+        context 'with merge_chain set to true with CA and chain' do
+            let(:params) {{
+                :cert_content  => 'cert1111',
+                :key_content   => 'key1111',
+                :service       => :undef,
+                :ensure        => 'present',
+                :cert_chain    => true,
+                :chain_name    => 'chain',
+                :chain_content => 'chain3333',
+                :ca_cert       => true,
+                :ca_name       => 'ca',
+                :ca_content    => 'ca2222',
+                :merge_chain   => true
+            }}
+
+            it { is_expected.to contain_concat('base.example.org_cert_merged') }
+            it { is_expected.to contain_concat__fragment('base.example.org.crt_certificate').
+                with_content(/cert1111/)
+            }
+            it { is_expected.to contain_concat__fragment('base.example.org.crt_ca').
+                with_content(/ca2222/)
+            }
+            it { is_expected.to contain_concat__fragment('base.example.org.crt_chain').
+                with_content(/chain3333/)
+            }
+            it { is_expected.to contain_file('/etc/ssl/private/base.example.org.key').
+                with_content(/key1111/)
+            }
+            it { is_expected.to contain_file('/etc/ssl/certs/ca.crt').
+                with_content(/ca2222/)
+            }
+            it { is_expected.to contain_file('/etc/ssl/certs/chain.crt').
+                with_content(/chain3333/)
+            }
+        end
+
+        context 'with merge_chain set to false and merge_key set to true with neither chain nor CA' do
+            let(:params) {{
+                :cert_content  => 'cert1111',
+                :key_content   => 'key1111',
+                :service       => :undef,
+                :ensure        => 'present',
+                :merge_chain   => false,
+                :merge_key     => true
+            }}
+
+            it { is_expected.to contain_concat('base.example.org_cert_merged') }
+            it { is_expected.to contain_concat__fragment('base.example.org.crt_certificate').
+                with_content(/cert1111/)
+            }
+            it { is_expected.to contain_concat__fragment('base.example.org.crt_key').
+                with_content(/key1111/)
+            }
+            it { is_expected.not_to contain_concat__fragment('base.example.org.crt_ca') }
+            it { is_expected.not_to contain_concat__fragment('base.example.org.crt_chain') }
+            it { is_expected.to contain_file('/etc/ssl/private/base.example.org.key').
+                with_content(/key1111/)
+            }
+        end
+
+        context 'with merge_chain set to false and merge_key set to true with chain and CA set' do
+            let(:params) {{
+                :cert_content  => 'cert1111',
+                :key_content   => 'key1111',
+                :service       => :undef,
+                :ensure        => 'present',
+                :cert_chain    => true,
+                :chain_name    => 'chain',
+                :chain_content => 'chain3333',
+                :ca_cert       => true,
+                :ca_name       => 'ca',
+                :ca_content    => 'ca2222',
+                :merge_chain   => false,
+                :merge_key     => true
+            }}
+
+            it { is_expected.to contain_concat('base.example.org_cert_merged') }
+            it { is_expected.to contain_concat__fragment('base.example.org.crt_certificate').
+                with_content(/cert1111/)
+            }
+            it { is_expected.to contain_concat__fragment('base.example.org.crt_key').
+                with_content(/key1111/)
+            }
+            it { is_expected.not_to contain_concat__fragment('base.example.org.crt_ca') }
+            it { is_expected.not_to contain_concat__fragment('base.example.org.crt_chain') }
+            it { is_expected.to contain_file('/etc/ssl/private/base.example.org.key').
+                with_content(/key1111/)
+            }
+            it { is_expected.to contain_file('/etc/ssl/certs/ca.crt').
+                with_content(/ca2222/)
+            }
+            it { is_expected.to contain_file('/etc/ssl/certs/chain.crt').
+                with_content(/chain3333/)
+            }
+        end
+
+        context 'with merge_chain and merge_key set to true with chain' do
+            let(:params) {{
+                :cert_content  => 'cert1111',
+                :key_content   => 'key1111',
+                :service       => :undef,
+                :ensure        => 'present',
+                :cert_chain    => true,
+                :chain_name    => 'chain',
+                :chain_content => 'chain3333',
+                :merge_chain   => true,
+                :merge_key     => true
+            }}
+
+            it { is_expected.to contain_concat('base.example.org_cert_merged') }
+            it { is_expected.to contain_concat__fragment('base.example.org.crt_certificate').
+                with_content(/cert1111/)
+            }
+            it { is_expected.to contain_concat__fragment('base.example.org.crt_key').
+                with_content(/key1111/)
+            }
+            it {is_expected.to contain_concat__fragment('base.example.org.crt_chain').
+                with_content(/chain3333/)
+            }
+            it { is_expected.to contain_file('/etc/ssl/private/base.example.org.key').
+                with_content(/key1111/)
+            }
+            it { is_expected.to contain_file('/etc/ssl/certs/chain.crt').
+                with_content(/chain3333/)
+            }
+        end
+
+        context 'with merge_chain and merge_key set to true with CA and chain' do
+            let(:params) {{
+                :cert_content  => 'cert1111',
+                :key_content   => 'key1111',
+                :service       => :undef,
+                :ensure        => 'present',
+                :cert_chain    => true,
+                :chain_name    => 'chain',
+                :chain_content => 'chain3333',
+                :ca_cert       => true,
+                :ca_name       => 'ca',
+                :ca_content    => 'ca2222',
+                :merge_chain   => true,
+                :merge_key     => true
+            }}
+
+            it { is_expected.to contain_concat('base.example.org_cert_merged') }
+            it { is_expected.to contain_concat__fragment('base.example.org.crt_certificate').
+                with_content(/cert1111/)
+            }
+            it { is_expected.to contain_concat__fragment('base.example.org.crt_key').
+                with_content(/key1111/)
+            }
+            it { is_expected.to contain_concat__fragment('base.example.org.crt_ca').
+                with_content(/ca2222/)
+            }
+            it { is_expected.to contain_concat__fragment('base.example.org.crt_chain').
+                with_content(/chain3333/)
+            }
+            it { is_expected.to contain_file('/etc/ssl/private/base.example.org.key').
+                with_content(/key1111/)
+            }
+            it { is_expected.to contain_file('/etc/ssl/certs/ca.crt').
+                with_content(/ca2222/)
+            }
+            it { is_expected.to contain_file('/etc/ssl/certs/chain.crt').
+                with_content(/chain3333/)
+            }
+        end
+
+        context 'with dhparam file' do
+            let(:params) {{
+                :service     => :undef,
+                :ensure      => 'present',
+                :dhparam     => true,
+                :source_path => 'puppet:///site_certs/base.example.org',
+            }}
+
+            it { is_expected.to contain_file('/etc/ssl/certs/base.example.org_dh2048.pem') }
+        end
+
+        context 'with dhparam file, with ensure => absent' do
+            let(:params) {{
+                :service     => :undef,
+                :ensure      => 'absent',
+                :dhparam     => true,
+                :source_path => 'puppet:///site_certs/base.example.org',
+            }}
+
+            it { is_expected.to contain_file('/etc/ssl/certs/base.example.org_dh2048.pem').
+                with_ensure('absent')
+            }
+        end
+
+        context 'with dhparam file with contents overriding source_path' do
+            let(:params) {{
+                :service         => :undef,
+                :ensure          => 'present',
+                :dhparam         => true,
+                :dhparam_content => 'dh4444',
+                :source_path     => 'puppet:///site_certs/base.example.org',
+            }}
+
+            it { is_expected.to contain_file('/etc/ssl/certs/base.example.org_dh2048.pem').
+                with_content(/dh4444/)
+            }
+        end
+
+        context 'with dhparam file with source_path' do
+            let(:params) {{
+                :service         => :undef,
+                :ensure          => 'present',
+                :dhparam         => true,
+                :source_path     => 'puppet:///site_certs/base.example.org',
+            }}
+
+            it { is_expected.to contain_file('/etc/ssl/certs/base.example.org_dh2048.pem').
+                with_source(/puppet:\/\/\/site_certs\/base.example.org\/dh2048\.pem/)
+            }
+        end
+
+        context 'with dhparam file with custom name' do
+            let(:params) {{
+                :service      => :undef,
+                :ensure       => 'present',
+                :dhparam      => true,
+                :dhparam_file => 'dhparam.crt',
+                :source_path  => 'puppet:///site_certs/base.example.org',
+            }}
+
+            it { is_expected.to contain_file('/etc/ssl/certs/base.example.org_dhparam.crt').
+                with_source(/puppet:\/\/\/site_certs\/base.example.org\/dhparam\.crt/)
+            }
+        end
+
+        context 'with a custom user set' do
+            let(:params) {{
+                :cert_content  => 'cert1111',
+                :key_content   => 'key1111',
+                :service       => :undef,
+                :ensure        => 'present',
+                :cert_chain    => true,
+                :chain_name    => 'chain',
+                :chain_content => 'chain3333',
+                :ca_cert       => true,
+                :ca_name       => 'ca',
+                :ca_content    => 'ca2222',
+                :dhparam       => true,
+                :owner         => 'newowner',
+            }}
+
+            it { is_expected.to contain_file('/etc/ssl/certs/base.example.org.crt').
+                with_owner('newowner')
+            }
+            it { is_expected.to contain_file('/etc/ssl/private/base.example.org.key').
+                with_owner('newowner')
+            }
+            it { is_expected.to contain_file('/etc/ssl/certs/ca.crt').
+                with_owner('newowner')
+            }
+            it { is_expected.to contain_file('/etc/ssl/certs/chain.crt').
+                with_owner('newowner')
+            }
+            it { is_expected.to contain_file('/etc/ssl/certs/base.example.org_dh2048.pem').
+                with_owner('newowner')
+            }
+        end
+
+        context 'with a custom group set' do
+            let(:params) {{
+                :cert_content  => 'cert1111',
+                :key_content   => 'key1111',
+                :service       => :undef,
+                :ensure        => 'present',
+                :cert_chain    => true,
+                :chain_name    => 'chain',
+                :chain_content => 'chain3333',
+                :ca_cert       => true,
+                :ca_name       => 'ca',
+                :ca_content    => 'ca2222',
+                :dhparam       => true,
+                :group         => 'newgroup',
+            }}
+
+            it { is_expected.to contain_file('/etc/ssl/certs/base.example.org.crt').
+                with_group('newgroup')
+            }
+            it { is_expected.to contain_file('/etc/ssl/certs/base.example.org_dh2048.pem').
+                with_group('newgroup')
+            }
+            it { is_expected.to contain_file('/etc/ssl/private/base.example.org.key').
+                with_group('newgroup')
+            }
+            it { is_expected.to contain_file('/etc/ssl/certs/ca.crt').
+                with_group('newgroup')
+            }
+            it { is_expected.to contain_file('/etc/ssl/certs/chain.crt').
+                with_group('newgroup')
+            }
+        end
+
+        context 'with a custom file and directory modes set' do
+            let(:params) {{
+                :cert_content  => 'cert1111',
+                :key_content   => 'key1111',
+                :service       => :undef,
+                :ensure        => 'present',
+                :cert_chain    => true,
+                :chain_name    => 'chain',
+                :chain_content => 'chain3333',
+                :ca_cert       => true,
+                :ca_name       => 'ca',
+                :ca_content    => 'ca2222',
+                :cert_mode     => '0700',
+                :key_mode      => '0400',
+                :cert_dir_mode => '0500',
+                :key_dir_mode  => '0500',
+                :dhparam       => true,
+            }}
+
+            it { is_expected.to contain_file('/etc/ssl/certs').
+                with_ensure('directory')
+            }
+            it { is_expected.to contain_file('/etc/ssl/certs').
+                with_mode('0500')
+            }
+            it { is_expected.to contain_file('/etc/ssl/private').
+                with_ensure('directory')
+            }
+            it { is_expected.to contain_file('/etc/ssl/private').
+                with_mode('0500')
+            }
+            it { is_expected.to contain_file('/etc/ssl/certs/base.example.org.crt').
+                with_mode('0700')
+            }
+            it { is_expected.to contain_file('/etc/ssl/certs/base.example.org_dh2048.pem').
+                with_mode('0700')
+            }
+            it { is_expected.to contain_file('/etc/ssl/private/base.example.org.key').
+                with_mode('0400')
+            }
+            it { is_expected.to contain_file('/etc/ssl/certs/ca.crt').
+                with_mode('0700')
+            }
+            it { is_expected.to contain_file('/etc/ssl/certs/chain.crt').
+                with_mode('0700')
+            }
+        end
+
+        context 'with custom extensions set' do
+            let(:params) {{
+                :cert_content  => 'cert1111',
+                :key_content   => 'key1111',
+                :service       => :undef,
+                :ensure        => 'present',
+                :cert_chain    => true,
+                :chain_name    => 'chain',
+                :chain_content => 'chain3333',
+                :ca_cert       => true,
+                :ca_name       => 'ca',
+                :ca_content    => 'ca2222',
+                :cert_ext      => '.pem',
+                :key_ext       => '.pem',
+                :ca_ext        => '.pem',
+                :chain_ext     => '.pem',
+            }}
+
+            it { is_expected.to contain_file('/etc/ssl/certs/base.example.org.pem') }
+            it { is_expected.to contain_file('/etc/ssl/private/base.example.org.pem') }
+            it { is_expected.to contain_file('/etc/ssl/certs/ca.pem') }
+            it { is_expected.to contain_file('/etc/ssl/certs/chain.pem') }
+        end
     end
-  end
-
-  context "on Debian-like setup for the remaining tests" do
-
-    let(:facts) { {
-      :osfamily                  => 'Debian',
-      :operatingsystem           => 'Debian',
-      :lsbdistid                 => 'Debian',
-      :lsbdistcodename           => 'wheezy',
-      :operatingsystemrelease    => '7.3',
-      :operatingsystemmajrelease => '7',
-    } }
-
-    # This define requires the certs class, so make sure it's defined
-    let :pre_condition do
-      'class { "certs":
-        cert_path => "/etc/ssl/certs",
-        key_path  => "/etc/ssl/private",
-      }'
-    end
-
-    context 'with only cert and key content set' do
-      let(:params) {
-        {
-          :cert_content => 'cert1111',
-          :key_content  => 'key1111',
-          :service      => :undef,
-        }
-      }
-
-      it { is_expected.to contain_file('/etc/ssl/certs/base.example.org.crt').with_content(/cert1111/) }
-      it { is_expected.to contain_file('/etc/ssl/private/base.example.org.key').with_content(/key1111/) }
-    end
-
-    context 'with ensure => absent' do
-      let(:params) {
-        {
-          :cert_content => 'cert',
-          :key_content  => 'key',
-          :service      => :undef,
-          :ensure       => 'absent'
-        }
-      }
-
-      it { is_expected.to contain_file('/etc/ssl/certs/base.example.org.crt').with_ensure('absent') }
-      it { is_expected.to contain_file('/etc/ssl/private/base.example.org.key').with_ensure('absent') }
-    end
-
-    context 'with CA cert' do
-      let(:params) {
-        {
-          :cert_content => 'cert1111',
-          :key_content  => 'key1111',
-          :service      => :undef,
-          :ca_cert      => true,
-          :ca_name      => 'ca',
-          :ca_content   => 'ca2222',
-          :ensure       => 'present'
-        }
-      }
-
-      it { is_expected.to contain_file('/etc/ssl/certs/base.example.org.crt').with_content(/cert1111/) }
-      it { is_expected.to contain_file('/etc/ssl/private/base.example.org.key').with_content(/key1111/) }
-      it { is_expected.to contain_file('/etc/ssl/certs/ca.crt').with_content(/ca2222/) }
-    end
-
-    context 'with chain cert' do
-      let(:params) {
-        {
-          :cert_content => 'cert1111',
-          :key_content  => 'key1111',
-          :service      => :undef,
-          :ca_cert      => true,
-          :ca_name      => 'chain',
-          :ca_content   => 'chain3333',
-          :ensure       => 'present'
-        }
-      }
-
-      it { is_expected.to contain_file('/etc/ssl/certs/base.example.org.crt').with_content(/cert1111/) }
-      it { is_expected.to contain_file('/etc/ssl/private/base.example.org.key').with_content(/key1111/) }
-      it { is_expected.to contain_file('/etc/ssl/certs/chain.crt').with_content(/chain3333/) }
-    end
-
-    context 'with merge_chain set to true with CA' do
-      let(:params) {
-        {
-          :cert_content => 'cert1111',
-          :key_content  => 'key1111',
-          :service      => :undef,
-          :ensure       => 'present',
-          :ca_cert      => true,
-          :ca_name      => 'ca',
-          :ca_content   => 'ca2222',
-          :merge_chain  => true
-        }
-      }
-
-      it { is_expected.to contain_concat('base.example.org_cert_merged') }
-      it {
-        is_expected.to contain_concat__fragment('base.example.org.crt_certificate').with(
-          :content => /cert1111/ )
-      }
-      it {
-        is_expected.to contain_concat__fragment('base.example.org.crt_ca').with(
-          :content => /ca2222/ )
-      }
-      it { is_expected.to contain_file('/etc/ssl/private/base.example.org.key').with_content(/key1111/) }
-      it { is_expected.to contain_file('/etc/ssl/certs/ca.crt').with_content(/ca2222/) }
-    end
-
-    context 'with merge_chain set to true with chain' do
-      let(:params) {
-        {
-          :cert_content  => 'cert1111',
-          :key_content   => 'key1111',
-          :service       => :undef,
-          :ensure        => 'present',
-          :cert_chain    => true,
-          :chain_name    => 'chain',
-          :chain_content => 'chain3333',
-          :merge_chain   => true
-        }
-      }
-
-      it { is_expected.to contain_concat('base.example.org_cert_merged') }
-      it {
-        is_expected.to contain_concat__fragment('base.example.org.crt_certificate').with(
-          :content => /cert1111/ )
-      }
-      it {
-        is_expected.to contain_concat__fragment('base.example.org.crt_chain').with(
-          :content => /chain3333/ )
-      }
-      it { is_expected.to contain_file('/etc/ssl/private/base.example.org.key').with_content(/key1111/) }
-      it { is_expected.to contain_file('/etc/ssl/certs/chain.crt').with_content(/chain3333/) }
-    end
-
-    context 'with merge_chain set to true with CA and chain' do
-      let(:params) {
-        {
-          :cert_content  => 'cert1111',
-          :key_content   => 'key1111',
-          :service       => :undef,
-          :ensure        => 'present',
-          :cert_chain    => true,
-          :chain_name    => 'chain',
-          :chain_content => 'chain3333',
-          :ca_cert       => true,
-          :ca_name       => 'ca',
-          :ca_content    => 'ca2222',
-          :merge_chain   => true
-        }
-      }
-
-      it { is_expected.to contain_concat('base.example.org_cert_merged') }
-      it {
-        is_expected.to contain_concat__fragment('base.example.org.crt_certificate').with(
-          :content => /cert1111/ )
-      }
-      it {
-        is_expected.to contain_concat__fragment('base.example.org.crt_ca').with(
-          :content => /ca2222/ )
-      }
-      it {
-        is_expected.to contain_concat__fragment('base.example.org.crt_chain').with(
-          :content => /chain3333/ )
-      }
-      it { is_expected.to contain_file('/etc/ssl/private/base.example.org.key').with_content(/key1111/) }
-      it { is_expected.to contain_file('/etc/ssl/certs/ca.crt').with_content(/ca2222/) }
-      it { is_expected.to contain_file('/etc/ssl/certs/chain.crt').with_content(/chain3333/) }
-    end
-
-    context 'with merge_chain set to false and merge_key set to true with neither chain nor CA' do
-      let(:params) {
-        {
-          :cert_content  => 'cert1111',
-          :key_content   => 'key1111',
-          :service       => :undef,
-          :ensure        => 'present',
-          :merge_chain   => false,
-          :merge_key     => true
-        }
-      }
-
-      it { is_expected.to contain_concat('base.example.org_cert_merged') }
-      it {
-        is_expected.to contain_concat__fragment('base.example.org.crt_certificate').with(
-          :content => /cert1111/ )
-      }
-      it {
-        is_expected.to contain_concat__fragment('base.example.org.crt_key').with(
-          :content => /key1111/ )
-      }
-      it {
-        is_expected.not_to contain_concat__fragment('base.example.org.crt_ca')
-      }
-      it {
-        is_expected.not_to contain_concat__fragment('base.example.org.crt_chain')
-      }
-      it { is_expected.to contain_file('/etc/ssl/private/base.example.org.key').with_content(/key1111/) }
-    end
-
-    context 'with merge_chain set to false and merge_key set to true with chain and CA set' do
-      let(:params) {
-        {
-          :cert_content  => 'cert1111',
-          :key_content   => 'key1111',
-          :service       => :undef,
-          :ensure        => 'present',
-          :cert_chain    => true,
-          :chain_name    => 'chain',
-          :chain_content => 'chain3333',
-          :ca_cert       => true,
-          :ca_name       => 'ca',
-          :ca_content    => 'ca2222',
-          :merge_chain   => false,
-          :merge_key     => true
-        }
-      }
-
-      it { is_expected.to contain_concat('base.example.org_cert_merged') }
-      it {
-        is_expected.to contain_concat__fragment('base.example.org.crt_certificate').with(
-          :content => /cert1111/ )
-      }
-      it {
-        is_expected.to contain_concat__fragment('base.example.org.crt_key').with(
-          :content => /key1111/ )
-      }
-      it {
-        is_expected.not_to contain_concat__fragment('base.example.org.crt_ca')
-      }
-      it {
-        is_expected.not_to contain_concat__fragment('base.example.org.crt_chain')
-      }
-      it { is_expected.to contain_file('/etc/ssl/private/base.example.org.key').with_content(/key1111/) }
-      it { is_expected.to contain_file('/etc/ssl/certs/ca.crt').with_content(/ca2222/) }
-      it { is_expected.to contain_file('/etc/ssl/certs/chain.crt').with_content(/chain3333/) }
-    end
-
-    context 'with merge_chain and merge_key set to true with chain' do
-      let(:params) {
-        {
-          :cert_content  => 'cert1111',
-          :key_content   => 'key1111',
-          :service       => :undef,
-          :ensure        => 'present',
-          :cert_chain    => true,
-          :chain_name    => 'chain',
-          :chain_content => 'chain3333',
-          :merge_chain   => true,
-          :merge_key     => true
-        }
-      }
-
-      it { is_expected.to contain_concat('base.example.org_cert_merged') }
-      it {
-        is_expected.to contain_concat__fragment('base.example.org.crt_certificate').with(
-          :content => /cert1111/ )
-      }
-      it {
-        is_expected.to contain_concat__fragment('base.example.org.crt_key').with(
-          :content => /key1111/ )
-      }
-      it {
-        is_expected.to contain_concat__fragment('base.example.org.crt_chain').with(
-          :content => /chain3333/ )
-      }
-      it { is_expected.to contain_file('/etc/ssl/private/base.example.org.key').with_content(/key1111/) }
-      it { is_expected.to contain_file('/etc/ssl/certs/chain.crt').with_content(/chain3333/) }
-    end
-
-    context 'with merge_chain and merge_key set to true with CA and chain' do
-      let(:params) {
-        {
-          :cert_content  => 'cert1111',
-          :key_content   => 'key1111',
-          :service       => :undef,
-          :ensure        => 'present',
-          :cert_chain    => true,
-          :chain_name    => 'chain',
-          :chain_content => 'chain3333',
-          :ca_cert       => true,
-          :ca_name       => 'ca',
-          :ca_content    => 'ca2222',
-          :merge_chain   => true,
-          :merge_key     => true
-        }
-      }
-
-      it { is_expected.to contain_concat('base.example.org_cert_merged') }
-      it {
-        is_expected.to contain_concat__fragment('base.example.org.crt_certificate').with(
-          :content => /cert1111/ )
-      }
-      it {
-        is_expected.to contain_concat__fragment('base.example.org.crt_key').with(
-          :content => /key1111/ )
-      }
-      it {
-        is_expected.to contain_concat__fragment('base.example.org.crt_ca').with(
-          :content => /ca2222/ )
-      }
-      it {
-        is_expected.to contain_concat__fragment('base.example.org.crt_chain').with(
-          :content => /chain3333/ )
-      }
-      it { is_expected.to contain_file('/etc/ssl/private/base.example.org.key').with_content(/key1111/) }
-      it { is_expected.to contain_file('/etc/ssl/certs/ca.crt').with_content(/ca2222/) }
-      it { is_expected.to contain_file('/etc/ssl/certs/chain.crt').with_content(/chain3333/) }
-    end
-
-    context 'with a custom user set' do
-      let(:params) {
-        {
-          :cert_content  => 'cert1111',
-          :key_content   => 'key1111',
-          :service       => :undef,
-          :ensure        => 'present',
-          :cert_chain    => true,
-          :chain_name    => 'chain',
-          :chain_content => 'chain3333',
-          :ca_cert       => true,
-          :ca_name       => 'ca',
-          :ca_content    => 'ca2222',
-          :owner         => 'newowner',
-        }
-      }
-
-      it { is_expected.to contain_file('/etc/ssl/certs/base.example.org.crt').with_owner('newowner') }
-      it { is_expected.to contain_file('/etc/ssl/private/base.example.org.key').with_owner('newowner') }
-      it { is_expected.to contain_file('/etc/ssl/certs/ca.crt').with_owner('newowner') }
-      it { is_expected.to contain_file('/etc/ssl/certs/chain.crt').with_owner('newowner') }
-    end
-
-    context 'with a custom group set' do
-      let(:params) {
-        {
-          :cert_content  => 'cert1111',
-          :key_content   => 'key1111',
-          :service       => :undef,
-          :ensure        => 'present',
-          :cert_chain    => true,
-          :chain_name    => 'chain',
-          :chain_content => 'chain3333',
-          :ca_cert       => true,
-          :ca_name       => 'ca',
-          :ca_content    => 'ca2222',
-          :group         => 'newgroup',
-        }
-      }
-
-      it { is_expected.to contain_file('/etc/ssl/certs/base.example.org.crt').with_group('newgroup') }
-      it { is_expected.to contain_file('/etc/ssl/private/base.example.org.key').with_group('newgroup') }
-      it { is_expected.to contain_file('/etc/ssl/certs/ca.crt').with_group('newgroup') }
-      it { is_expected.to contain_file('/etc/ssl/certs/chain.crt').with_group('newgroup') }
-    end
-
-    context 'with a custom file and directory modes set' do
-      let(:params) {
-        {
-          :cert_content  => 'cert1111',
-          :key_content   => 'key1111',
-          :service       => :undef,
-          :ensure        => 'present',
-          :cert_chain    => true,
-          :chain_name    => 'chain',
-          :chain_content => 'chain3333',
-          :ca_cert       => true,
-          :ca_name       => 'ca',
-          :ca_content    => 'ca2222',
-          :cert_mode     => '0700',
-          :key_mode      => '0400',
-          :cert_dir_mode => '0500',
-          :key_dir_mode  => '0500',
-        }
-      }
-
-      it { is_expected.to contain_file('/etc/ssl/certs').with_ensure('directory') }
-      it { is_expected.to contain_file('/etc/ssl/certs').with_mode('0500') }
-      it { is_expected.to contain_file('/etc/ssl/private').with_ensure('directory') }
-      it { is_expected.to contain_file('/etc/ssl/private').with_mode('0500') }
-
-      it { is_expected.to contain_file('/etc/ssl/certs/base.example.org.crt').with_mode('0700') }
-      it { is_expected.to contain_file('/etc/ssl/private/base.example.org.key').with_mode('0400') }
-      it { is_expected.to contain_file('/etc/ssl/certs/ca.crt').with_mode('0700') }
-      it { is_expected.to contain_file('/etc/ssl/certs/chain.crt').with_mode('0700') }
-    end
-
-    context 'with custom extensions set' do
-      let(:params) {
-        {
-          :cert_content  => 'cert1111',
-          :key_content   => 'key1111',
-          :service       => :undef,
-          :ensure        => 'present',
-          :cert_chain    => true,
-          :chain_name    => 'chain',
-          :chain_content => 'chain3333',
-          :ca_cert       => true,
-          :ca_name       => 'ca',
-          :ca_content    => 'ca2222',
-          :cert_ext      => '.pem',
-          :key_ext       => '.pem',
-          :ca_ext        => '.pem',
-          :chain_ext     => '.pem',
-        }
-      }
-
-      it { is_expected.to contain_file('/etc/ssl/certs/base.example.org.pem') }
-      it { is_expected.to contain_file('/etc/ssl/private/base.example.org.pem') }
-      it { is_expected.to contain_file('/etc/ssl/certs/ca.pem') }
-      it { is_expected.to contain_file('/etc/ssl/certs/chain.pem') }
-    end
-  end
 end


### PR DESCRIPTION
* Add options to distribute a dhparam file in a site
* Spacing cleanup in .pp files
* Fix stdlib version in .fixtures.yml
* Clean up spacing in spec files
* Remove unneeded settings from pre conditions in spec tests
* Reorder and fill in missing option documentation for certs::site in README
* Update Rakefile to make tests faster when run multiple times
* Fix "ensure" in site.pp so the code is cleaner
* Add spec tests for new dhparam options
Fixes #10 